### PR TITLE
Use unique uri as key when uploading multiple objects

### DIFF
--- a/pyetp/client.py
+++ b/pyetp/client.py
@@ -328,7 +328,7 @@ class ETPClient(ETPConnection):
             PutDataObjectsResponse
 
         response = await self.send(
-            PutDataObjects(dataObjects={p.resource.name: p for p in objs})
+            PutDataObjects(dataObjects={p.resource.uri: p for p in objs})
         )
         # logger.info(f"objects {response=:}")
         assert isinstance(response, PutDataObjectsResponse), "Expected PutDataObjectsResponse"


### PR DESCRIPTION
[This line](https://github.com/equinor/pyetp/blob/a4a5bfd4023c4eeeb518f2c11db4a9c8f50ea10d/pyetp/client.py#L331C13-L331C75) assumes that the passed in `DataObject`-arguments have unique names (`DataObject.resource.name`). However, this is often not the case when uploading multiple data-objects using the `put_resqml_objects`-method due to [this line](https://github.com/equinor/pyetp/blob/a4a5bfd4023c4eeeb518f2c11db4a9c8f50ea10d/pyetp/client.py#L357). For meshes it is often the case that there are several objects with both the same title and type (they might differ in indices).

A solution is to replace the `p.resource.name` [here](https://github.com/equinor/pyetp/blob/a4a5bfd4023c4eeeb518f2c11db4a9c8f50ea10d/pyetp/client.py#L331C13-L331C75) by `p.resource.uri` as that is guaranteed to be unique (a non-unique value would be a bug on the caller side as the RESQML-spec calls for unique uuids for each object, and hence unique uris).