### PR TITLE
fix to creating dataspace URI from a string variable

### DIFF
--- a/pyetp/uri.py
+++ b/pyetp/uri.py
@@ -51,8 +51,10 @@ class DataspaceURI(_DataspaceURI, _Mixin):
         if isinstance(v, DataObjectURI):
             return cls.from_name(v.dataspace)
         if isinstance(v, str):
-            return cls(v) if v.startswith('eml://') else cls.from_name(v)
-
+            if v.startswith('eml://'):
+                return cls(v) if v.endswith('\')') else cls.from_name(DataObjectURI(v).dataspace)
+            else:
+                return cls.from_name(v)
         raise TypeError(f"Type {type(v)} not supported dataspace uri")
 
 


### PR DESCRIPTION
The incoming variable in "DataSpaceURI.from_any" could be a string that contains a DataObject URI