### PR TITLE
Limit test-job to read permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
+
     uses: equinor/pyetp/.github/workflows/ci.yml@main
     with:
       event_type: ${{ github.event_name}}


### PR DESCRIPTION
This is for the ci-workflow run from the publish-workflow.