### PR TITLE
Allow strings in `list_objects`-method

### DIFF
--- a/src/pyetp/client.py
+++ b/src/pyetp/client.py
@@ -455,12 +455,12 @@ class ETPClient(ETPConnection):
             raise Exception("Max one / in dataspace name")
         return DataspaceURI.from_name(ds)
 
-    def list_objects(self, dataspace_uri: DataspaceURI, depth: int = 1) -> list:
+    def list_objects(self, dataspace_uri: DataspaceURI | str, depth: int = 1) -> list:
         return self.send(
             GetResources(
                 scope=ContextScopeKind.TARGETS_OR_SELF,
                 context=ContextInfo(
-                    uri=dataspace_uri.raw_uri,
+                    uri=str(dataspace_uri),
                     depth=depth,
                     dataObjectTypes=[],
                     navigableEdges=RelationshipKind.PRIMARY,

--- a/tests/test_etp_clientv2.py
+++ b/tests/test_etp_clientv2.py
@@ -354,6 +354,8 @@ async def test_resqml_objects(eclient: ETPClient, duri: DataspaceURI):
     _ = await eclient.commit_transaction(transaction_uuid=transaction_uuid)
 
     grr = await eclient.list_objects(duri)
+    # Test that both DataspaceURI-objects and strings are supported
+    assert grr == await eclient.list_objects(str(duri))
     uris = [r.uri for r in grr.resources]
 
     assert len(uris) == 5


### PR DESCRIPTION
The previous implementation only worked when passing the `dataspace_uri` as a `DataspaceURI`-object. We now allow for both strings and `DataspaceURI`-objects. A test is also added.