### PR TITLE
Fix persistent connection

### DIFF
--- a/src/pyetp/client.py
+++ b/src/pyetp/client.py
@@ -1506,16 +1506,9 @@ async def etp_persistent_connect(
         max_size=max_message_size,
         additional_headers=additional_headers,
     ):
-        try:
-            async with ETPClient(
-                ws=ws,
-                etp_timeout=etp_timeout,
-                max_message_size=max_message_size,
-            ) as etp_client:
-                yield etp_client
-        except websockets.ConnectionClosed as e:
-            logger.info(
-                f"Websockets connection closed with message '{e}'. Starting new "
-                "connection"
-            )
-            continue
+        async with ETPClient(
+            ws=ws,
+            etp_timeout=etp_timeout,
+            max_message_size=max_message_size,
+        ) as etp_client:
+            yield etp_client

--- a/tests/test_etp_clientv2.py
+++ b/tests/test_etp_clientv2.py
@@ -131,6 +131,27 @@ async def test_persistent_connect_ws_closing() -> None:
     reason="websocket for test server not open",
 )
 @pytest.mark.asyncio
+async def test_persistent_connect_ws_closing_operations() -> None:
+    counter = 0
+    async for etp_client in etp_persistent_connect(uri=etp_server_url):
+        if counter == 10:
+            break
+
+        counter += 1
+
+        await etp_client.ws.close(1009)
+
+        with pytest.raises(websockets.ConnectionClosed):
+            await etp_client.get_dataspaces()
+
+    assert counter == 10
+
+
+@pytest.mark.skipif(
+    not check_if_server_is_accesible(),
+    reason="websocket for test server not open",
+)
+@pytest.mark.asyncio
 async def test_persistent_connect_etp_closing() -> None:
     async for etp_client in etp_persistent_connect(uri=etp_server_url):
         break


### PR DESCRIPTION
The pattern suggested by the websockets library (https://websockets.readthedocs.io/en/stable/faq/client.html#how-do-i-reconnect-when-the-connection-drops) should be applied at the user-level, not inside the generator itself. As such, an example of using `etp_persistent_connect` is:
```python
async for etp_client in etp_persistent_connect(...):
    try:
        <do-etp stuff>
    except websockets.ConnectionClosed:
        continue
```
which will persist the connection if the websockets connection is suddenly dropped.