### PR TITLE
change logging to warn

### DIFF
--- a/src/pyetp/client.py
+++ b/src/pyetp/client.py
@@ -437,7 +437,7 @@ class ETPClient(ETPConnection):
             pass
         except TimeoutError:
             if close_session_sent:
-                logger.error(
+                logger.warning(
                     "Websockets connection was not closed within "
                     f"{self.etp_timeout or 10} seconds after the "
                     "`CloseSession`-message was sent"


### PR DESCRIPTION
@Schoyen Can we change this line to warning instead of error? Because it does not affect normal operation of the library. What do you think?