### PR TITLE
Publish documentation to GitHub Pages

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build
     uses: equinor/ops-actions/.github/workflows/mkdocs.yml@v9.34.0
     permissions:
-      contents: read
+      contents: read # Required to checkout the repository
     with:
       python_version: 3.13
       dependency_group: docs
@@ -25,7 +25,7 @@ jobs:
     if: needs.build.outputs.artifact_uploaded == 'true'
     uses: equinor/ops-actions/.github/workflows/github-pages.yml@v9.34.0
     permissions:
-      pages: write
-      id-token: write
+      id-token: write # Required to authenticate to GitHub Pages
+      pages: write # Required to publish to GitHub Pages
     with:
       artifact_name: ${{ needs.build.outputs.artifact_name }}


### PR DESCRIPTION
Add a GitHub Actions workflow that calls the following reusable workflows from [ops-actions](https://github.com/equinor/ops-actions):

- [MkDocs](https://github.com/equinor/ops-actions/blob/v9.34.0/.github/workflows/mkdocs.yml): Installs the specified Python version and required dependencies, and builds the MkDocs site configured in the `mkdocs.yml` file. If the workflow was triggered on push to branch `main`, the build artifact will be uploaded.
- [GitHub Pages](https://github.com/equinor/ops-actions/blob/v9.34.0/.github/workflows/github-pages.yml): If a build artifact was uploaded, deploys it to this repository's GitHub Pages.

The workflow is configured to run on:
- **Pull request**: verifies that docs can be successfully built before merging.
- **Push to main**:  builds and publishes docs to GitHub Pages.

Closes #41
