### PR TITLE
Feature/hina/populate dataobjectreferences

### DIFF
--- a/src/rddms_io/client.py
+++ b/src/rddms_io/client.py
@@ -1481,7 +1481,7 @@ class RDDMSClient:
         if len(ml_uris) == 0:
             raise ValueError("No uris in input 'ml_uris'")
 
-        return await asyncio.gather(
+        models = await asyncio.gather(
             *[
                 self._download_model(
                     ml_uri=str(ml_uri),
@@ -1491,6 +1491,16 @@ class RDDMSClient:
                 for ml_uri in ml_uris
             ]
         )
+
+        if download_linked_objects:
+            models = [
+                model._replace(obj=model.populate_data_references())
+                if model.linked_models
+                else model
+                for model in models
+            ]
+
+        return models
 
     async def _recv_get_data_objects(
         self, gdo: GetDataObjects

--- a/src/rddms_io/client.py
+++ b/src/rddms_io/client.py
@@ -1438,7 +1438,7 @@ class RDDMSClient:
         ml_uris: Sequence[str | DataObjectURI],
         download_arrays: bool = False,
         download_linked_objects: bool = False,
-        populate_references: bool = False,
+        populate_linked_references: bool = False,
     ) -> list[RDDMSModel]:
         """
         Download RESQML-models from the RDDMS server.
@@ -1473,13 +1473,12 @@ class RDDMSClient:
             `obj_EpcExternalPartReference`- and
             `EpcExternalPartReference`-objects.  Default is `False` meaning no
             linked objects will be downloaded.
-        populate_references
+        populate_linked_references
             When set to `True` (requires `download_linked_objects=True`),
             the ``DataObjectReference`` fields in each model's ``obj`` are
             replaced with the actual objects from ``linked_models`` via
             [`RDDMSModel.populate_data_references`][rddms_io.data_types.RDDMSModel.populate_data_references].
-            This allows methods like ``get_xy_grid()`` to work without
-            passing any extra parameters. Default is `False`.
+            Default is `False`.
 
         Returns
         -------
@@ -1488,6 +1487,12 @@ class RDDMSClient:
         """
         if len(ml_uris) == 0:
             raise ValueError("No uris in input 'ml_uris'")
+
+        if populate_linked_references and not download_linked_objects:
+            raise ValueError(
+                "'populate_linked_references=True' requires "
+                "'download_linked_objects=True'."
+            )
 
         models = await asyncio.gather(
             *[
@@ -1500,12 +1505,9 @@ class RDDMSClient:
             ]
         )
 
-        if populate_references and download_linked_objects:
+        if populate_linked_references:
             models = [
-                model._replace(obj=model.populate_data_references())
-                if model.linked_models
-                else model
-                for model in models
+                model._replace(obj=model.populate_data_references()) for model in models
             ]
 
         return models

--- a/src/rddms_io/client.py
+++ b/src/rddms_io/client.py
@@ -1438,6 +1438,7 @@ class RDDMSClient:
         ml_uris: Sequence[str | DataObjectURI],
         download_arrays: bool = False,
         download_linked_objects: bool = False,
+        populate_references: bool = False,
     ) -> list[RDDMSModel]:
         """
         Download RESQML-models from the RDDMS server.
@@ -1472,6 +1473,13 @@ class RDDMSClient:
             `obj_EpcExternalPartReference`- and
             `EpcExternalPartReference`-objects.  Default is `False` meaning no
             linked objects will be downloaded.
+        populate_references
+            When set to `True` (requires `download_linked_objects=True`),
+            the ``DataObjectReference`` fields in each model's ``obj`` are
+            replaced with the actual objects from ``linked_models`` via
+            [`RDDMSModel.populate_data_references`][rddms_io.data_types.RDDMSModel.populate_data_references].
+            This allows methods like ``get_xy_grid()`` to work without
+            passing any extra parameters. Default is `False`.
 
         Returns
         -------
@@ -1492,7 +1500,7 @@ class RDDMSClient:
             ]
         )
 
-        if download_linked_objects:
+        if populate_references and download_linked_objects:
             models = [
                 model._replace(obj=model.populate_data_references())
                 if model.linked_models

--- a/src/rddms_io/data_types.py
+++ b/src/rddms_io/data_types.py
@@ -1,3 +1,4 @@
+import copy
 import typing
 
 import numpy.typing as npt
@@ -5,6 +6,7 @@ import numpy.typing as npt
 import resqml_objects.v201 as ro
 from energistics.etp.v12.datatypes.object import Edge, Resource
 from energistics.types import ETPNumpyArrayType
+from resqml_objects.v201.utils import replace_data_object_references
 
 
 class RDDMSModel(typing.NamedTuple):
@@ -32,6 +34,27 @@ class RDDMSModel(typing.NamedTuple):
     obj: ro.AbstractCitedDataObject
     arrays: dict[str, npt.NDArray[ETPNumpyArrayType]]
     linked_models: list["RDDMSModel"]
+
+    def populate_data_references(self) -> ro.AbstractCitedDataObject:
+        """Return a copy of ``self.obj`` with ``DataObjectReference`` fields
+        replaced by the actual objects from ``self.linked_models``.
+
+        The original model is not modified.
+
+        Returns
+        -------
+        ro.AbstractCitedDataObject
+            A deep copy of ``self.obj`` where every ``DataObjectReference``
+            whose UUID matches a linked model's object has been replaced by
+            that object.
+        """
+        uuid_to_obj: dict[str, ro.AbstractCitedDataObject] = {
+            lm.obj.uuid: lm.obj for lm in self.linked_models
+        }
+
+        obj_copy = copy.deepcopy(self.obj)
+        replace_data_object_references(obj_copy, uuid_to_obj)
+        return obj_copy
 
 
 class LinkedObjects(typing.NamedTuple):

--- a/src/rddms_io/data_types.py
+++ b/src/rddms_io/data_types.py
@@ -39,15 +39,20 @@ class RDDMSModel(typing.NamedTuple):
         """Return a copy of ``self.obj`` with ``DataObjectReference`` fields
         replaced by the actual objects from ``self.linked_models``.
 
-        The original model is not modified.
+        The original model is not modified. If ``linked_models`` is empty
+        or ``None``, the original ``obj`` is returned without copying.
 
         Returns
         -------
         ro.AbstractCitedDataObject
             A deep copy of ``self.obj`` where every ``DataObjectReference``
             whose UUID matches a linked model's object has been replaced by
-            that object.
+            that object, or the original ``self.obj`` if there are no
+            linked models.
         """
+        if not self.linked_models:
+            return self.obj
+
         uuid_to_obj: dict[str, ro.AbstractCitedDataObject] = {
             lm.obj.uuid: lm.obj for lm in self.linked_models
         }

--- a/src/rddms_io/sync_client.py
+++ b/src/rddms_io/sync_client.py
@@ -549,6 +549,7 @@ class RDDMSClientSync:
         ml_uris: Sequence[str | DataObjectURI],
         download_arrays: bool = False,
         download_linked_objects: bool = False,
+        populate_references: bool = False,
     ) -> list[RDDMSModel]:
         """
         Download RESQML-models from the RDDMS server. A model in this sense is
@@ -583,6 +584,13 @@ class RDDMSClientSync:
             `obj_EpcExternalPartReference`- and
             `EpcExternalPartReference`-objects.  Default is `False` meaning no
             linked objects will be downloaded.
+        populate_references
+            When set to `True` (requires `download_linked_objects=True`),
+            the ``DataObjectReference`` fields in each model's ``obj`` are
+            replaced with the actual objects from ``linked_models`` via
+            [`RDDMSModel.populate_data_references`][rddms_io.data_types.RDDMSModel.populate_data_references].
+            This allows methods like ``get_xy_grid()`` to work without
+            passing any extra parameters. Default is `False`.
 
         Returns
         -------
@@ -601,6 +609,7 @@ class RDDMSClientSync:
                     ml_uris=ml_uris,
                     download_arrays=download_arrays,
                     download_linked_objects=download_linked_objects,
+                    populate_references=populate_references,
                 )
 
         return run_coroutine_sync(download_models())

--- a/src/rddms_io/sync_client.py
+++ b/src/rddms_io/sync_client.py
@@ -549,7 +549,7 @@ class RDDMSClientSync:
         ml_uris: Sequence[str | DataObjectURI],
         download_arrays: bool = False,
         download_linked_objects: bool = False,
-        populate_references: bool = False,
+        populate_linked_references: bool = False,
     ) -> list[RDDMSModel]:
         """
         Download RESQML-models from the RDDMS server. A model in this sense is
@@ -584,13 +584,12 @@ class RDDMSClientSync:
             `obj_EpcExternalPartReference`- and
             `EpcExternalPartReference`-objects.  Default is `False` meaning no
             linked objects will be downloaded.
-        populate_references
+        populate_linked_references
             When set to `True` (requires `download_linked_objects=True`),
             the ``DataObjectReference`` fields in each model's ``obj`` are
             replaced with the actual objects from ``linked_models`` via
             [`RDDMSModel.populate_data_references`][rddms_io.data_types.RDDMSModel.populate_data_references].
-            This allows methods like ``get_xy_grid()`` to work without
-            passing any extra parameters. Default is `False`.
+            Default is `False`.
 
         Returns
         -------
@@ -609,7 +608,7 @@ class RDDMSClientSync:
                     ml_uris=ml_uris,
                     download_arrays=download_arrays,
                     download_linked_objects=download_linked_objects,
-                    populate_references=populate_references,
+                    populate_linked_references=populate_linked_references,
                 )
 
         return run_coroutine_sync(download_models())

--- a/src/resqml_objects/v201/generated.py
+++ b/src/resqml_objects/v201/generated.py
@@ -24027,8 +24027,78 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
         }
     )
 
+    @staticmethod
+    def _find_lattice_in_points(
+        points: AbstractPoint3dArray,
+    ) -> Point3dLatticeArray | None:
+        """Find a `Point3dLatticeArray` from geometry points.
+
+        Returns the lattice if found, or `None` if the points do not
+        contain a `Point3dLatticeArray`.
+        """
+        if isinstance(points, Point3dLatticeArray):
+            return points
+        if isinstance(points, Point3dZValueArray) and isinstance(
+            points.supporting_geometry, Point3dLatticeArray
+        ):
+            return points.supporting_geometry
+        return None
+
+    def _get_lattice_array(
+        self,
+        supporting_representation: Self | None = None,
+    ) -> Point3dLatticeArray:
+        """Extract the `Point3dLatticeArray` from the geometry points.
+
+        Supports three cases:
+        1. `geometry.points` is a `Point3dLatticeArray` directly (scaffold
+           surface with no Z-values).
+        2. `geometry.points` is a `Point3dZValueArray` with a
+           `Point3dLatticeArray` as supporting geometry.
+        3. `geometry.points` is a `Point3dZValueArray` with a
+           `Point3dFromRepresentationLatticeArray` as supporting geometry,
+           where the lattice is resolved from the `supporting_representation`.
+        """
+        points = self.grid2d_patch.geometry.points
+
+        lattice = self._find_lattice_in_points(points)
+        if lattice is not None:
+            return lattice
+
+        if not isinstance(points, Point3dZValueArray):
+            raise NotImplementedError(
+                f"We do not support points of type {points.__class__.__name__}"
+            )
+
+        sg = points.supporting_geometry
+        if isinstance(sg, Point3dFromRepresentationLatticeArray):
+            if supporting_representation is None:
+                raise ValueError(
+                    "The supporting geometry is a "
+                    "'Point3dFromRepresentationLatticeArray', which requires "
+                    "the 'supporting_representation' parameter to resolve "
+                    "the lattice array."
+                )
+
+            sr_points = supporting_representation.grid2d_patch.geometry.points
+            lattice = self._find_lattice_in_points(sr_points)
+            if lattice is not None:
+                return lattice
+
+            raise NotImplementedError(
+                "The supporting representation's points are of type "
+                f"'{sr_points.__class__.__name__}', expected "
+                "'Point3dLatticeArray'."
+            )
+
+        raise NotImplementedError(
+            f"We do not support a supporting geometry of type '{sg.__class__.__name__}'"
+        )
+    
     def get_regular_surface_parameters(
-        self, crs: AbstractLocal3dCrs | None = None
+        self,
+        crs: AbstractLocal3dCrs | None = None,
+        supporting_representation: Self | None = None,
     ) -> RegularSurfaceParameters:
 
         crs_angle = 0.0
@@ -24038,20 +24108,7 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
             crs_angle = crs.areal_rotation.get_angle_in_rad()
             crs_origin = np.array([crs.xoffset, crs.yoffset])
 
-        points = self.grid2d_patch.geometry.points
-
-        if not isinstance(points, Point3dZValueArray):
-            raise NotImplementedError(
-                "We do not support getting the regular surface parameters for points "
-                f"of type {points.__class__.__name__}"
-            )
-
-        sg = points.supporting_geometry
-        if not isinstance(sg, Point3dLatticeArray):
-            raise NotImplementedError(
-                "We do not support getting the regular surface parameters for a "
-                f"supporting geometry of type {sg.__class__.__name__}"
-            )
+        sg = self._get_lattice_array(supporting_representation)
 
         shape = (
             self.grid2d_patch.slowest_axis_count,
@@ -24102,7 +24159,9 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
         )
 
     def get_xy_grid(
-        self, crs: AbstractLocal3dCrs | None = None
+        self,
+        crs: AbstractLocal3dCrs | None = None,
+        supporting_representation: Self | None = None,
     ) -> tuple[
         npt.NDArray[np.float64],
         npt.NDArray[np.float64],
@@ -24127,6 +24186,10 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
             have to be the same as referenced by the grid-object, but if it
             does not match a warning is raised. Setting `crs=None` avoids any
             transformation from the crs. Default is `None`.
+        supporting_representation: obj_Grid2dRepresentation | None
+            The supporting representation to resolve the lattice array from
+            when the supporting geometry is a
+            `Point3dFromRepresentationLatticeArray`. Default is `None`.
 
         Returns
         -------
@@ -24135,20 +24198,7 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
             to the surface described by the grid-object. For an unrotated
             surface this corresponds to a meshgrid.
         """
-        points = self.grid2d_patch.geometry.points
-
-        if not isinstance(points, Point3dZValueArray):
-            raise NotImplementedError(
-                "We do not support constructing the X, Y grid for points of type "
-                f"{points.__class__.__name__}"
-            )
-
-        sg = points.supporting_geometry
-        if not isinstance(sg, Point3dLatticeArray):
-            raise NotImplementedError(
-                "We do not support constructing the X, Y grid for a supporting "
-                f"geometry of type {sg.__class__.__name__}"
-            )
+        sg = self._get_lattice_array(supporting_representation)
 
         from resqml_objects.surface_helpers import RegularGridParameters
 

--- a/src/resqml_objects/v201/generated.py
+++ b/src/resqml_objects/v201/generated.py
@@ -24044,10 +24044,7 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
             return points.supporting_geometry
         return None
 
-    def _get_lattice_array(
-        self,
-        linked_representations: list[Self] | None = None,
-    ) -> Point3dLatticeArray:
+    def _get_lattice_array(self) -> Point3dLatticeArray:
         """Extract the `Point3dLatticeArray` from the geometry points.
 
         Supports three cases:
@@ -24057,9 +24054,9 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
            `Point3dLatticeArray` as supporting geometry.
         3. `geometry.points` is a `Point3dZValueArray` with a
            `Point3dFromRepresentationLatticeArray` as supporting geometry,
-           where the lattice is resolved by finding the matching
-           representation from `linked_representations` using the UUID
-           from the supporting representation reference.
+           where the `supporting_representation` field has been populated
+           with the actual object (via
+           `RDDMSModel.populate_data_references`).
         """
         points = self.grid2d_patch.geometry.points
 
@@ -24074,35 +24071,28 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
 
         sg = points.supporting_geometry
         if isinstance(sg, Point3dFromRepresentationLatticeArray):
-            ref_uuid = sg.supporting_representation.uuid
+            sup_rep = sg.supporting_representation
 
-            if linked_representations is None:
-                raise ValueError(
-                    "The supporting geometry is a "
-                    "'Point3dFromRepresentationLatticeArray' referencing "
-                    f"uuid '{ref_uuid}', but no 'linked_representations' "
-                    "were provided to resolve it."
+            if isinstance(sup_rep, obj_Grid2dRepresentation):
+                sr_points = sup_rep.grid2d_patch.geometry.points
+                lattice = self._find_lattice_in_points(sr_points)
+                if lattice is not None:
+                    return lattice
+
+                raise NotImplementedError(
+                    "The supporting representation's points are of type "
+                    f"'{sr_points.__class__.__name__}', expected "
+                    "'Point3dLatticeArray'."
                 )
 
-            matching = [rep for rep in linked_representations if rep.uuid == ref_uuid]
-
-            if len(matching) == 0:
-                raise ValueError(
-                    "The supporting geometry references a representation "
-                    f"with uuid '{ref_uuid}', but none of the "
-                    f"{len(linked_representations)} linked representations "
-                    "match this uuid."
-                )
-
-            sr_points = matching[0].grid2d_patch.geometry.points
-            lattice = self._find_lattice_in_points(sr_points)
-            if lattice is not None:
-                return lattice
-
-            raise NotImplementedError(
-                "The supporting representation's points are of type "
-                f"'{sr_points.__class__.__name__}', expected "
-                "'Point3dLatticeArray'."
+            raise ValueError(
+                "The supporting geometry is a "
+                "'Point3dFromRepresentationLatticeArray', but the "
+                "'supporting_representation' field has not been populated "
+                "with the actual object. Use "
+                "'RDDMSModel.populate_data_references()' or "
+                "'download_models(download_linked_objects=True)' to "
+                "resolve the reference."
             )
 
         raise NotImplementedError(
@@ -24112,7 +24102,6 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
     def get_regular_surface_parameters(
         self,
         crs: AbstractLocal3dCrs | None = None,
-        linked_representations: list[Self] | None = None,
     ) -> RegularSurfaceParameters:
 
         crs_angle = 0.0
@@ -24122,7 +24111,7 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
             crs_angle = crs.areal_rotation.get_angle_in_rad()
             crs_origin = np.array([crs.xoffset, crs.yoffset])
 
-        sg = self._get_lattice_array(linked_representations)
+        sg = self._get_lattice_array()
 
         shape = (
             self.grid2d_patch.slowest_axis_count,
@@ -24175,7 +24164,6 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
     def get_xy_grid(
         self,
         crs: AbstractLocal3dCrs | None = None,
-        linked_representations: list[Self] | None = None,
     ) -> tuple[
         npt.NDArray[np.float64],
         npt.NDArray[np.float64],
@@ -24200,12 +24188,6 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
             have to be the same as referenced by the grid-object, but if it
             does not match a warning is raised. Setting `crs=None` avoids any
             transformation from the crs. Default is `None`.
-        linked_representations: list[obj_Grid2dRepresentation] | None
-            A list of linked `obj_Grid2dRepresentation` objects. When the
-            supporting geometry is a `Point3dFromRepresentationLatticeArray`,
-            the correct representation is automatically selected by matching
-            the UUID from the supporting representation reference. Default
-            is `None`.
 
         Returns
         -------
@@ -24214,7 +24196,7 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
             to the surface described by the grid-object. For an unrotated
             surface this corresponds to a meshgrid.
         """
-        sg = self._get_lattice_array(linked_representations)
+        sg = self._get_lattice_array()
 
         from resqml_objects.surface_helpers import RegularGridParameters
 

--- a/src/resqml_objects/v201/generated.py
+++ b/src/resqml_objects/v201/generated.py
@@ -24046,7 +24046,7 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
 
     def _get_lattice_array(
         self,
-        supporting_representation: Self | None = None,
+        linked_representations: list[Self] | None = None,
     ) -> Point3dLatticeArray:
         """Extract the `Point3dLatticeArray` from the geometry points.
 
@@ -24057,7 +24057,9 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
            `Point3dLatticeArray` as supporting geometry.
         3. `geometry.points` is a `Point3dZValueArray` with a
            `Point3dFromRepresentationLatticeArray` as supporting geometry,
-           where the lattice is resolved from the `supporting_representation`.
+           where the lattice is resolved by finding the matching
+           representation from `linked_representations` using the UUID
+           from the supporting representation reference.
         """
         points = self.grid2d_patch.geometry.points
 
@@ -24072,15 +24074,27 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
 
         sg = points.supporting_geometry
         if isinstance(sg, Point3dFromRepresentationLatticeArray):
-            if supporting_representation is None:
+            ref_uuid = sg.supporting_representation.uuid
+
+            if linked_representations is None:
                 raise ValueError(
                     "The supporting geometry is a "
-                    "'Point3dFromRepresentationLatticeArray', which requires "
-                    "the 'supporting_representation' parameter to resolve "
-                    "the lattice array."
+                    "'Point3dFromRepresentationLatticeArray' referencing "
+                    f"uuid '{ref_uuid}', but no 'linked_representations' "
+                    "were provided to resolve it."
                 )
 
-            sr_points = supporting_representation.grid2d_patch.geometry.points
+            matching = [rep for rep in linked_representations if rep.uuid == ref_uuid]
+
+            if len(matching) == 0:
+                raise ValueError(
+                    "The supporting geometry references a representation "
+                    f"with uuid '{ref_uuid}', but none of the "
+                    f"{len(linked_representations)} linked representations "
+                    "match this uuid."
+                )
+
+            sr_points = matching[0].grid2d_patch.geometry.points
             lattice = self._find_lattice_in_points(sr_points)
             if lattice is not None:
                 return lattice
@@ -24098,7 +24112,7 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
     def get_regular_surface_parameters(
         self,
         crs: AbstractLocal3dCrs | None = None,
-        supporting_representation: Self | None = None,
+        linked_representations: list[Self] | None = None,
     ) -> RegularSurfaceParameters:
 
         crs_angle = 0.0
@@ -24108,7 +24122,7 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
             crs_angle = crs.areal_rotation.get_angle_in_rad()
             crs_origin = np.array([crs.xoffset, crs.yoffset])
 
-        sg = self._get_lattice_array(supporting_representation)
+        sg = self._get_lattice_array(linked_representations)
 
         shape = (
             self.grid2d_patch.slowest_axis_count,
@@ -24161,7 +24175,7 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
     def get_xy_grid(
         self,
         crs: AbstractLocal3dCrs | None = None,
-        supporting_representation: Self | None = None,
+        linked_representations: list[Self] | None = None,
     ) -> tuple[
         npt.NDArray[np.float64],
         npt.NDArray[np.float64],
@@ -24186,10 +24200,12 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
             have to be the same as referenced by the grid-object, but if it
             does not match a warning is raised. Setting `crs=None` avoids any
             transformation from the crs. Default is `None`.
-        supporting_representation: obj_Grid2dRepresentation | None
-            The supporting representation to resolve the lattice array from
-            when the supporting geometry is a
-            `Point3dFromRepresentationLatticeArray`. Default is `None`.
+        linked_representations: list[obj_Grid2dRepresentation] | None
+            A list of linked `obj_Grid2dRepresentation` objects. When the
+            supporting geometry is a `Point3dFromRepresentationLatticeArray`,
+            the correct representation is automatically selected by matching
+            the UUID from the supporting representation reference. Default
+            is `None`.
 
         Returns
         -------
@@ -24198,7 +24214,7 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
             to the surface described by the grid-object. For an unrotated
             surface this corresponds to a meshgrid.
         """
-        sg = self._get_lattice_array(supporting_representation)
+        sg = self._get_lattice_array(linked_representations)
 
         from resqml_objects.surface_helpers import RegularGridParameters
 

--- a/src/resqml_objects/v201/generated.py
+++ b/src/resqml_objects/v201/generated.py
@@ -24094,7 +24094,7 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
         raise NotImplementedError(
             f"We do not support a supporting geometry of type '{sg.__class__.__name__}'"
         )
-    
+
     def get_regular_surface_parameters(
         self,
         crs: AbstractLocal3dCrs | None = None,

--- a/src/resqml_objects/v201/utils.py
+++ b/src/resqml_objects/v201/utils.py
@@ -64,14 +64,21 @@ def _find_data_object_references(obj: typing.Any) -> list[ro.DataObjectReference
 
 
 def replace_data_object_references(
-    obj: typing.Any,
+    obj: ro.AbstractCitedDataObject,
     uuid_to_obj: dict[str, ro.AbstractCitedDataObject],
 ) -> None:
     """Recursively walk *obj* and replace ``DataObjectReference`` fields
     in-place when a matching UUID is found in *uuid_to_obj*."""
+    _replace_data_object_references(obj, uuid_to_obj)
+
+
+def _replace_data_object_references(
+    obj: typing.Any,
+    uuid_to_obj: dict[str, ro.AbstractCitedDataObject],
+) -> None:
     if isinstance(obj, list):
         for item in obj:
-            replace_data_object_references(item, uuid_to_obj)
+            _replace_data_object_references(item, uuid_to_obj)
         return
 
     try:
@@ -83,6 +90,6 @@ def replace_data_object_references(
         value = getattr(obj, f.name)
         if isinstance(value, ro.DataObjectReference):
             if value.uuid in uuid_to_obj:
-                object.__setattr__(obj, f.name, uuid_to_obj[value.uuid])
+                setattr(obj, f.name, uuid_to_obj[value.uuid])
         else:
-            replace_data_object_references(value, uuid_to_obj)
+            _replace_data_object_references(value, uuid_to_obj)

--- a/src/resqml_objects/v201/utils.py
+++ b/src/resqml_objects/v201/utils.py
@@ -61,3 +61,28 @@ def _find_data_object_references(obj: typing.Any) -> list[ro.DataObjectReference
             dors.extend(_find_data_object_references(getattr(obj, f.name)))
 
     return dors
+
+
+def replace_data_object_references(
+    obj: typing.Any,
+    uuid_to_obj: dict[str, ro.AbstractCitedDataObject],
+) -> None:
+    """Recursively walk *obj* and replace ``DataObjectReference`` fields
+    in-place when a matching UUID is found in *uuid_to_obj*."""
+    if isinstance(obj, list):
+        for item in obj:
+            replace_data_object_references(item, uuid_to_obj)
+        return
+
+    try:
+        _fields = fields(obj)
+    except TypeError:
+        return
+
+    for f in _fields:
+        value = getattr(obj, f.name)
+        if isinstance(value, ro.DataObjectReference):
+            if value.uuid in uuid_to_obj:
+                object.__setattr__(obj, f.name, uuid_to_obj[value.uuid])
+        else:
+            replace_data_object_references(value, uuid_to_obj)

--- a/tests/test_resqmlv201_objects.py
+++ b/tests/test_resqmlv201_objects.py
@@ -463,8 +463,6 @@ def test_point3d_from_representation_lattice_array() -> None:
 
     # Get expected X, Y from the supporting grid directly.
     expected_X, expected_Y = supporting_gri.get_xy_grid()
-    print("Expected X:\n", expected_X)
-    print("Expected Y:\n", expected_Y)
     expected_params = supporting_gri.get_regular_surface_parameters()
 
     # Create a grid that references the supporting grid via

--- a/tests/test_resqmlv201_objects.py
+++ b/tests/test_resqmlv201_objects.py
@@ -525,6 +525,7 @@ def test_point3d_from_representation_lattice_array() -> None:
         linked_models=[RDDMSModel(obj=supporting_gri, arrays={}, linked_models=[])],
     )
     populated_obj = model.populate_data_references()
+    assert isinstance(populated_obj, ro.obj_Grid2dRepresentation)
 
     X, Y = populated_obj.get_xy_grid()
     params = populated_obj.get_regular_surface_parameters()

--- a/tests/test_resqmlv201_objects.py
+++ b/tests/test_resqmlv201_objects.py
@@ -8,13 +8,13 @@ from xsdata.models.datatype import XmlDateTime
 
 import resqml_objects.v201 as ro
 from pyetp._version import version
+from rddms_io.data_types import RDDMSModel
 from resqml_objects.parsers import parse_resqml_v201_object
 from resqml_objects.serializers import (
     RO201Obj,
     RO201SubObj,
     serialize_resqml_v201_object,
 )
-from rddms_io.data_types import RDDMSModel
 from resqml_objects.surface_helpers import RegularGridParameters
 
 

--- a/tests/test_resqmlv201_objects.py
+++ b/tests/test_resqmlv201_objects.py
@@ -2,6 +2,7 @@ import dataclasses
 import datetime
 
 import numpy as np
+import pytest
 from lxml import etree
 from xsdata.models.datatype import XmlDateTime
 
@@ -422,3 +423,110 @@ def test_rotated_regular_grid_2d_representation() -> None:
 
     np.testing.assert_allclose(aligned_X, X)
     np.testing.assert_allclose(aligned_Y, Y)
+
+
+def test_point3d_from_representation_lattice_array() -> None:
+    """Test that get_xy_grid and get_regular_surface_parameters work when the
+    supporting geometry is a Point3dFromRepresentationLatticeArray, i.e., a
+    reference to another Grid2dRepresentation's lattice."""
+
+    shape = tuple(np.random.randint(10, 123, size=2).tolist())
+
+    x = np.linspace(0, 1, shape[0])
+    y = np.linspace(1, 2, shape[1])
+
+    origin = np.array([x[0], y[0]])
+    spacing = np.array([x[1] - x[0], y[1] - y[0]])
+    unit_vectors = np.eye(2)
+
+    crs = ro.obj_LocalDepth3dCrs(
+        citation=ro.Citation(title="Test CRS", originator="pyetp-tester"),
+        vertical_crs=ro.VerticalCrsEpsgCode(epsg_code=1234),
+        projected_crs=ro.ProjectedCrsEpsgCode(epsg_code=23031),
+    )
+
+    epc = ro.obj_EpcExternalPartReference(
+        citation=ro.Citation(title="Test epc", originator="pyetp-tester"),
+    )
+
+    # Create a "supporting" grid with Point3dLatticeArray (like ST15M04_VEL).
+    supporting_gri = ro.obj_Grid2dRepresentation.from_regular_surface(
+        citation=ro.Citation(title="Supporting grid", originator="pyetp-tester"),
+        crs=crs,
+        epc_external_part_reference=epc,
+        shape=shape,
+        origin=origin,
+        spacing=spacing,
+        unit_vec_1=unit_vectors[:, 0],
+        unit_vec_2=unit_vectors[:, 1],
+    )
+
+    # Get expected X, Y from the supporting grid directly.
+    expected_X, expected_Y = supporting_gri.get_xy_grid()
+    print("Expected X:\n", expected_X)
+    print("Expected Y:\n", expected_Y)
+    expected_params = supporting_gri.get_regular_surface_parameters()
+
+    # Create a grid that references the supporting grid via
+    # Point3dFromRepresentationLatticeArray (like the Landmark Kolje surface).
+    referencing_gri = ro.obj_Grid2dRepresentation(
+        citation=ro.Citation(title="Referencing grid", originator="pyetp-tester"),
+        surface_role=ro.SurfaceRole.MAP,
+        grid2d_patch=ro.Grid2dPatch(
+            patch_index=0,
+            slowest_axis_count=shape[0],
+            fastest_axis_count=shape[1],
+            geometry=ro.PointGeometry(
+                local_crs=ro.DataObjectReference.from_object(crs),
+                points=ro.Point3dZValueArray(
+                    supporting_geometry=ro.Point3dFromRepresentationLatticeArray(
+                        node_indices_on_supporting_representation=ro.IntegerLatticeArray(
+                            start_value=0,
+                            offset=[
+                                ro.IntegerConstantArray(
+                                    value=1, count=shape[0] - 1
+                                ),
+                                ro.IntegerConstantArray(
+                                    value=1, count=shape[1] - 1
+                                ),
+                            ],
+                        ),
+                        supporting_representation=ro.DataObjectReference.from_object(
+                            supporting_gri
+                        ),
+                    ),
+                    zvalues=ro.DoubleHdf5Array(
+                        values=ro.Hdf5Dataset(
+                            path_in_hdf_file="/RESQML/test/zvalues",
+                            hdf_proxy=ro.DataObjectReference.from_object(epc),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    # Verify that the supporting geometry is the expected type.
+    sg = referencing_gri.grid2d_patch.geometry.points.supporting_geometry
+    assert isinstance(sg, ro.Point3dFromRepresentationLatticeArray)
+
+    # Without supporting_representation, get_xy_grid should raise ValueError.
+    with pytest.raises(ValueError, match="supporting_representation"):
+        referencing_gri.get_xy_grid()
+
+    with pytest.raises(ValueError, match="supporting_representation"):
+        referencing_gri.get_regular_surface_parameters()
+
+    # With supporting_representation, it should resolve the lattice.
+    X, Y = referencing_gri.get_xy_grid(supporting_representation=supporting_gri)
+    params = referencing_gri.get_regular_surface_parameters(
+        supporting_representation=supporting_gri
+    )
+
+    np.testing.assert_allclose(X, expected_X)
+    np.testing.assert_allclose(Y, expected_Y)
+
+    assert params.shape == expected_params.shape
+    np.testing.assert_allclose(params.origin, expected_params.origin)
+    np.testing.assert_allclose(params.spacing, expected_params.spacing)
+    np.testing.assert_allclose(params.angle, expected_params.angle)

--- a/tests/test_resqmlv201_objects.py
+++ b/tests/test_resqmlv201_objects.py
@@ -2,7 +2,6 @@ import dataclasses
 import datetime
 
 import numpy as np
-import pytest
 from lxml import etree
 from xsdata.models.datatype import XmlDateTime
 
@@ -510,11 +509,17 @@ def test_point3d_from_representation_lattice_array() -> None:
 
     # Without populate_data_references, get_xy_grid should raise ValueError
     # because the supporting_representation is still a DataObjectReference.
-    with pytest.raises(ValueError, match="populate_data_references"):
+    try:
         referencing_gri.get_xy_grid()
+        assert False, "Expected ValueError"
+    except ValueError:
+        pass
 
-    with pytest.raises(ValueError, match="populate_data_references"):
+    try:
         referencing_gri.get_regular_surface_parameters()
+        assert False, "Expected ValueError"
+    except ValueError:
+        pass
 
     # After populate_data_references, get_xy_grid should work without
     # any extra parameters because the DataObjectReference has been

--- a/tests/test_resqmlv201_objects.py
+++ b/tests/test_resqmlv201_objects.py
@@ -483,12 +483,8 @@ def test_point3d_from_representation_lattice_array() -> None:
                         node_indices_on_supporting_representation=ro.IntegerLatticeArray(
                             start_value=0,
                             offset=[
-                                ro.IntegerConstantArray(
-                                    value=1, count=shape[0] - 1
-                                ),
-                                ro.IntegerConstantArray(
-                                    value=1, count=shape[1] - 1
-                                ),
+                                ro.IntegerConstantArray(value=1, count=shape[0] - 1),
+                                ro.IntegerConstantArray(value=1, count=shape[1] - 1),
                             ],
                         ),
                         supporting_representation=ro.DataObjectReference.from_object(

--- a/tests/test_resqmlv201_objects.py
+++ b/tests/test_resqmlv201_objects.py
@@ -14,6 +14,7 @@ from resqml_objects.serializers import (
     RO201SubObj,
     serialize_resqml_v201_object,
 )
+from rddms_io.data_types import RDDMSModel
 from resqml_objects.surface_helpers import RegularGridParameters
 
 
@@ -449,7 +450,7 @@ def test_point3d_from_representation_lattice_array() -> None:
         citation=ro.Citation(title="Test epc", originator="pyetp-tester"),
     )
 
-    # Create a "supporting" grid with Point3dLatticeArray (like ST15M04_VEL).
+    # Create a "supporting" grid with Point3dLatticeArray.
     supporting_gri = ro.obj_Grid2dRepresentation.from_regular_surface(
         citation=ro.Citation(title="Supporting grid", originator="pyetp-tester"),
         crs=crs,
@@ -466,7 +467,7 @@ def test_point3d_from_representation_lattice_array() -> None:
     expected_params = supporting_gri.get_regular_surface_parameters()
 
     # Create a grid that references the supporting grid via
-    # Point3dFromRepresentationLatticeArray (like the Landmark Kolje surface).
+    # Point3dFromRepresentationLatticeArray.
     referencing_gri = ro.obj_Grid2dRepresentation(
         citation=ro.Citation(title="Referencing grid", originator="pyetp-tester"),
         surface_role=ro.SurfaceRole.MAP,
@@ -507,36 +508,26 @@ def test_point3d_from_representation_lattice_array() -> None:
         points.supporting_geometry, ro.Point3dFromRepresentationLatticeArray
     )
 
-    # Without linked_representations, get_xy_grid should raise ValueError.
-    with pytest.raises(ValueError, match="linked_representations"):
+    # Without populate_data_references, get_xy_grid should raise ValueError
+    # because the supporting_representation is still a DataObjectReference.
+    with pytest.raises(ValueError, match="populate_data_references"):
         referencing_gri.get_xy_grid()
 
-    with pytest.raises(ValueError, match="linked_representations"):
+    with pytest.raises(ValueError, match="populate_data_references"):
         referencing_gri.get_regular_surface_parameters()
 
-    # With linked_representations containing a wrong uuid, should raise ValueError.
-    wrong_gri = ro.obj_Grid2dRepresentation.from_regular_surface(
-        citation=ro.Citation(title="Wrong grid", originator="pyetp-tester"),
-        crs=crs,
-        epc_external_part_reference=epc,
-        shape=shape,
-        origin=origin,
-        spacing=spacing,
-        unit_vec_1=unit_vectors[:, 0],
-        unit_vec_2=unit_vectors[:, 1],
+    # After populate_data_references, get_xy_grid should work without
+    # any extra parameters because the DataObjectReference has been
+    # replaced with the actual object.
+    model = RDDMSModel(
+        obj=referencing_gri,
+        arrays={},
+        linked_models=[RDDMSModel(obj=supporting_gri, arrays={}, linked_models=[])],
     )
-    with pytest.raises(ValueError, match="none of the"):
-        referencing_gri.get_xy_grid(linked_representations=[wrong_gri])
+    populated_obj = model.populate_data_references()
 
-    # With linked_representations, it should automatically find the correct
-    # representation by matching the uuid from the supporting geometry
-    # reference.
-    X, Y = referencing_gri.get_xy_grid(
-        linked_representations=[wrong_gri, supporting_gri]
-    )
-    params = referencing_gri.get_regular_surface_parameters(
-        linked_representations=[supporting_gri]
-    )
+    X, Y = populated_obj.get_xy_grid()
+    params = populated_obj.get_regular_surface_parameters()
 
     np.testing.assert_allclose(X, expected_X)
     np.testing.assert_allclose(Y, expected_Y)

--- a/tests/test_resqmlv201_objects.py
+++ b/tests/test_resqmlv201_objects.py
@@ -507,17 +507,35 @@ def test_point3d_from_representation_lattice_array() -> None:
         points.supporting_geometry, ro.Point3dFromRepresentationLatticeArray
     )
 
-    # Without supporting_representation, get_xy_grid should raise ValueError.
-    with pytest.raises(ValueError, match="supporting_representation"):
+    # Without linked_representations, get_xy_grid should raise ValueError.
+    with pytest.raises(ValueError, match="linked_representations"):
         referencing_gri.get_xy_grid()
 
-    with pytest.raises(ValueError, match="supporting_representation"):
+    with pytest.raises(ValueError, match="linked_representations"):
         referencing_gri.get_regular_surface_parameters()
 
-    # With supporting_representation, it should resolve the lattice.
-    X, Y = referencing_gri.get_xy_grid(supporting_representation=supporting_gri)
+    # With linked_representations containing a wrong uuid, should raise ValueError.
+    wrong_gri = ro.obj_Grid2dRepresentation.from_regular_surface(
+        citation=ro.Citation(title="Wrong grid", originator="pyetp-tester"),
+        crs=crs,
+        epc_external_part_reference=epc,
+        shape=shape,
+        origin=origin,
+        spacing=spacing,
+        unit_vec_1=unit_vectors[:, 0],
+        unit_vec_2=unit_vectors[:, 1],
+    )
+    with pytest.raises(ValueError, match="none of the"):
+        referencing_gri.get_xy_grid(linked_representations=[wrong_gri])
+
+    # With linked_representations, it should automatically find the correct
+    # representation by matching the uuid from the supporting geometry
+    # reference.
+    X, Y = referencing_gri.get_xy_grid(
+        linked_representations=[wrong_gri, supporting_gri]
+    )
     params = referencing_gri.get_regular_surface_parameters(
-        supporting_representation=supporting_gri
+        linked_representations=[supporting_gri]
     )
 
     np.testing.assert_allclose(X, expected_X)

--- a/tests/test_resqmlv201_objects.py
+++ b/tests/test_resqmlv201_objects.py
@@ -503,8 +503,11 @@ def test_point3d_from_representation_lattice_array() -> None:
     )
 
     # Verify that the supporting geometry is the expected type.
-    sg = referencing_gri.grid2d_patch.geometry.points.supporting_geometry
-    assert isinstance(sg, ro.Point3dFromRepresentationLatticeArray)
+    points = referencing_gri.grid2d_patch.geometry.points
+    assert isinstance(points, ro.Point3dZValueArray)
+    assert isinstance(
+        points.supporting_geometry, ro.Point3dFromRepresentationLatticeArray
+    )
 
     # Without supporting_representation, get_xy_grid should raise ValueError.
     with pytest.raises(ValueError, match="supporting_representation"):

--- a/tests/test_resqmlv201_objects.py
+++ b/tests/test_resqmlv201_objects.py
@@ -2,6 +2,7 @@ import dataclasses
 import datetime
 
 import numpy as np
+import pytest
 from lxml import etree
 from xsdata.models.datatype import XmlDateTime
 
@@ -509,17 +510,11 @@ def test_point3d_from_representation_lattice_array() -> None:
 
     # Without populate_data_references, get_xy_grid should raise ValueError
     # because the supporting_representation is still a DataObjectReference.
-    try:
+    with pytest.raises(ValueError, match="populate_data_references"):
         referencing_gri.get_xy_grid()
-        assert False, "Expected ValueError"
-    except ValueError:
-        pass
 
-    try:
+    with pytest.raises(ValueError, match="populate_data_references"):
         referencing_gri.get_regular_surface_parameters()
-        assert False, "Expected ValueError"
-    except ValueError:
-        pass
 
     # After populate_data_references, get_xy_grid should work without
     # any extra parameters because the DataObjectReference has been


### PR DESCRIPTION
**Summary**
Landmark surfaces uploaded by dsif-orchestrator use Point3dFromRepresentationLatticeArray as their supporting geometry instead of Point3dLatticeArray. This means the surface doesn't store its own grid definition (origin, spacing, unit vectors) — it references another Grid2dRepresentation that has it. Previously, get_xy_grid() and get_regular_surface_parameters() only supported Point3dLatticeArray directly and would crash with NotImplementedError on these surfaces.

**Changes**

- Added _find_lattice_in_points() static method that extracts a Point3dLatticeArray from geometry points, handling both cases: points being a lattice directly, or points being a Point3dZValueArray with a lattice as supporting geometry.

- Added _get_lattice_array() method that resolves the lattice from the Point3dFromRepresentationLatticeArray supporting geometry. Only the simplest form is supported: trivial node indices (start_value=0, offset value=1). Works automatically when the DataObjectReference has been populated with the actual object.

- Added populate_data_references() method on RDDMSModel that returns a copy of the model's object with all DataObjectReference fields replaced by the actual objects from linked_models, matched by UUID. The original model is not modified.

- Added replace_data_object_references() utility function in resqml_objects/v201/utils.py for recursively replacing DataObjectReference fields in dataclass objects.

- Added populate_linked_references flag to download_models() in both async and sync clients. When set to True (requires download_linked_objects=True), references are automatically replaced with actual objects after download. Raises ValueError if populate_linked_references=True but download_linked_objects=False. Default is False to preserve backward compatibility.

- Added unit test test_point3d_from_representation_lattice_array covering both the error case (unpopulated references) and the success case (after populate_data_references).