### PR TITLE
Avoid crashing if a Dataspace does not validate when listing dataspaces

### DIFF
--- a/src/energistics/etp/v12/protocol/dataspace/get_dataspaces_response.py
+++ b/src/energistics/etp/v12/protocol/dataspace/get_dataspaces_response.py
@@ -1,9 +1,12 @@
+import logging
 import typing
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 import energistics.base
 from energistics.etp.v12.datatypes.object import Dataspace
+
+logger = logging.getLogger(__name__)
 
 
 @energistics.base.add_protocol_avro_metadata
@@ -32,3 +35,15 @@ class GetDataspacesResponse(energistics.base.ETPBaseProtocolModel):
     }
 
     dataspaces: list[Dataspace] = Field(default_factory=list)
+
+    @field_validator("dataspaces", mode="before")
+    def keep_only_valid_items(value: typing.Any) -> list[Dataspace]:
+        assert isinstance(value, list)
+
+        valid: list[Dataspace] = []
+        for raw in value:
+            try:
+                valid.append(Dataspace.model_validate(raw))
+            except ValueError as e:
+                logger.warning(f"Dataspace failed validation: {str(e)}")
+        return valid


### PR DESCRIPTION
* Add custom "before" validator to the GetDataspacesResponse class that can exclude "raw" Dataspace objects that fail validation.