### PR TITLE
add is_supported_regular_surface and yflip to RegularSurfaces

### DIFF
--- a/src/energistics/avro_handler.py
+++ b/src/energistics/avro_handler.py
@@ -119,14 +119,12 @@ def decode_message(
     message: bytes, decompression_func: Callable[[bytes], bytes] | None = None
 ) -> tuple[MessageHeader, energistics.base.ETPBaseProtocolModel]:
     with io.BytesIO(message) as fo:
-        # TODO: Remove the `#type: ignore`-below once a new release of
-        # `fastavro` is in place (greater than `1.12.1`).
         header_record = fastavro.read.schemaless_reader(
             fo=fo,
             writer_schema=MessageHeader.avro_schema,
             return_record_name=True,
             return_named_type_override=True,
-        )  # type: ignore
+        )
         assert isinstance(header_record, dict)
         header = MessageHeader(**header_record)
         body_bytes = fo.read()
@@ -146,14 +144,12 @@ def decode_message(
         body_bytes = decompression_func(body_bytes)
 
     with io.BytesIO(body_bytes) as fo:
-        # TODO: Remove the `#type: ignore`-below once a new release of
-        # `fastavro` is in place (greater than `1.12.1`).
         body_record = fastavro.read.schemaless_reader(
             fo=fo,
             writer_schema=body_cls.avro_schema,
             return_record_name=True,
             return_named_type_override=True,
-        )  # type: ignore
+        )
         assert isinstance(body_record, dict)
         body = body_cls(**body_record)
 

--- a/src/resqml_objects/data_types.py
+++ b/src/resqml_objects/data_types.py
@@ -9,3 +9,4 @@ class RegularSurfaceParameters(typing.NamedTuple):
     origin: typing.Annotated[npt.NDArray[np.float64], dict(shape=(2,))]
     spacing: typing.Annotated[npt.NDArray[np.float64], dict(shape=(2,))]
     angle: float
+    yflip: typing.Optional[bool] = False

--- a/src/resqml_objects/v201/generated.py
+++ b/src/resqml_objects/v201/generated.py
@@ -24099,6 +24099,30 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
             f"We do not support a supporting geometry of type '{sg.__class__.__name__}'"
         )
 
+    def is_supported_regular_surface(self) -> bool:
+        """Return True if this `Grid2dRepresentation` has Z-values and a
+        subsequent call to `get_regular_surface_parameters` is expected to
+        succeed.
+
+        Returns False for:
+        - Scaffold surfaces — `geometry.points` is a `Point3dLatticeArray`
+        directly, with no Z-values.
+        - Surfaces using `Point3dFromRepresentationLatticeArray` whose
+        `supporting_representation` has not been resolved (call
+        `RDDMSModel.populate_data_references()` first).
+        - Surfaces whose lattice offsets are not `DoubleConstantArray`.
+        - Anything else `get_regular_surface_parameters` cannot handle.
+        """
+        if not isinstance(self.grid2d_patch.geometry.points, Point3dZValueArray):
+            return False
+
+        try:
+            self.get_regular_surface_parameters()
+        except (NotImplementedError, ValueError, AttributeError):
+            return False
+
+        return True
+
     def get_regular_surface_parameters(
         self,
         crs: AbstractLocal3dCrs | None = None,

--- a/src/resqml_objects/v201/generated.py
+++ b/src/resqml_objects/v201/generated.py
@@ -18866,7 +18866,28 @@ class Point3dLatticeArray(AbstractPoint3dArray):
             "min_occurs": 1,
         },
     )
+    def offset_vectors_are_right_handed(self) -> bool:
+        if len(self.offset)<2:
+            ## should not happen
+            return True
+        unit_vec_0 = np.array(
+            [self.offset[0].offset.coordinate1, self.offset[0].offset.coordinate2]
+        )
+        unit_vec_1 = np.array(
+            [self.offset[1].offset.coordinate1, self.offset[1].offset.coordinate2]
+        )
+        # right-handed means that the second unit vector is 90 degrees counter-clockwise from the first unit vector
+        unit_vec_angle_0 = np.atan2(unit_vec_0[1], unit_vec_0[0])  # result is in range [-pi..+pi]
+        unit_vec_angle_1 = np.atan2(unit_vec_1[1], unit_vec_1[0])
+        
+        vec_diff = unit_vec_angle_1 - unit_vec_angle_0
+        while vec_diff < -np.pi:
+            vec_diff = vec_diff + 2*np.pi
+        while vec_diff > np.pi:
+            vec_diff = vec_diff - 2*np.pi
 
+        # for right-handed, unit_vec_angle_1 - unit_vec_angle_0 is pi/2
+        return bool(vec_diff > 0)
 
 @dataclass(slots=True, kw_only=True)
 class PointGeometry(AbstractGeometry):
@@ -24175,14 +24196,16 @@ class obj_Grid2dRepresentation(AbstractSurfaceRepresentation):
         # Here we assume that the axis order is EASTING_NORTHING, and that the
         # second unit vector lies 90 degrees counter-clockwise of the first
         # unit vector.
-
         angle = float(np.atan2(unit_vec_1[1], unit_vec_1[0]))
+
+        # If the axis order is inverted (i.e. left-handed), we must set the yflip flag
 
         return RegularSurfaceParameters(
             shape=shape,
             origin=origin + crs_origin,
             spacing=spacing,
             angle=angle + crs_angle,
+            yflip=not sg.offset_vectors_are_right_handed(),
         )
 
     def get_xy_grid(

--- a/src/resqml_objects/v201/generated.py
+++ b/src/resqml_objects/v201/generated.py
@@ -18866,8 +18866,9 @@ class Point3dLatticeArray(AbstractPoint3dArray):
             "min_occurs": 1,
         },
     )
+
     def offset_vectors_are_right_handed(self) -> bool:
-        if len(self.offset)<2:
+        if len(self.offset) < 2:
             ## should not happen
             return True
         unit_vec_0 = np.array(
@@ -18877,17 +18878,20 @@ class Point3dLatticeArray(AbstractPoint3dArray):
             [self.offset[1].offset.coordinate1, self.offset[1].offset.coordinate2]
         )
         # right-handed means that the second unit vector is 90 degrees counter-clockwise from the first unit vector
-        unit_vec_angle_0 = np.atan2(unit_vec_0[1], unit_vec_0[0])  # result is in range [-pi..+pi]
+        unit_vec_angle_0 = np.atan2(
+            unit_vec_0[1], unit_vec_0[0]
+        )  # result is in range [-pi..+pi]
         unit_vec_angle_1 = np.atan2(unit_vec_1[1], unit_vec_1[0])
-        
+
         vec_diff = unit_vec_angle_1 - unit_vec_angle_0
         while vec_diff < -np.pi:
-            vec_diff = vec_diff + 2*np.pi
+            vec_diff = vec_diff + 2 * np.pi
         while vec_diff > np.pi:
-            vec_diff = vec_diff - 2*np.pi
+            vec_diff = vec_diff - 2 * np.pi
 
         # for right-handed, unit_vec_angle_1 - unit_vec_angle_0 is pi/2
         return bool(vec_diff > 0)
+
 
 @dataclass(slots=True, kw_only=True)
 class PointGeometry(AbstractGeometry):

--- a/tests/test_etp_objects/conftest.py
+++ b/tests/test_etp_objects/conftest.py
@@ -19,14 +19,12 @@ def _avro_roundtrip(
         bs = fb.getvalue()
 
     with io.BytesIO(bs) as fb:
-        # TODO: Remove the `#type: ignore`-below once a new release of
-        # `fastavro` is in place (greater than `1.12.1`).
         record = fastavro.read.schemaless_reader(
             fo=fb,
             writer_schema=cls.avro_schema,
             return_record_name=True,
             return_named_type_override=True,
-        )  # type: ignore
+        )
 
         assert isinstance(record, dict | bytes)
         if isinstance(record, dict):

--- a/tests/test_resqmlv201_objects.py
+++ b/tests/test_resqmlv201_objects.py
@@ -658,6 +658,8 @@ def test_is_supported_regular_surface() -> None:
     assert regular_gri.is_supported_regular_surface() is True
 
     # Case 2: scaffold — geometry.points is a bare Point3dLatticeArray, no zvalues.
+    regular_points = regular_gri.grid2d_patch.geometry.points
+    assert isinstance(regular_points, ro.Point3dZValueArray)
     scaffold_gri = ro.obj_Grid2dRepresentation(
         citation=ro.Citation(title="Scaffold", originator="pyetp-tester"),
         surface_role=ro.SurfaceRole.MAP,
@@ -667,7 +669,7 @@ def test_is_supported_regular_surface() -> None:
             fastest_axis_count=shape[1],
             geometry=ro.PointGeometry(
                 local_crs=ro.DataObjectReference.from_object(crs),
-                points=regular_gri.grid2d_patch.geometry.points.supporting_geometry,
+                points=regular_points.supporting_geometry,
             ),
         ),
     )

--- a/tests/test_resqmlv201_objects.py
+++ b/tests/test_resqmlv201_objects.py
@@ -617,3 +617,105 @@ def test_point3d_from_representation_lattice_array() -> None:
     np.testing.assert_allclose(params.origin, expected_params.origin)
     np.testing.assert_allclose(params.spacing, expected_params.spacing)
     np.testing.assert_allclose(params.angle, expected_params.angle)
+
+
+def test_is_supported_regular_surface() -> None:
+    """`is_supported_regular_surface` should distinguish between:
+    - A regular Z-value surface (supported).
+    - A scaffold surface with no Z-values (not supported).
+    - A surface with an unresolved Point3dFromRepresentationLatticeArray
+      reference (not supported until populate_data_references is called).
+    """
+    shape = tuple(np.random.randint(10, 123, size=2).tolist())
+
+    x = np.linspace(0, 1, shape[0])
+    y = np.linspace(1, 2, shape[1])
+
+    origin = np.array([x[0], y[0]])
+    spacing = np.array([x[1] - x[0], y[1] - y[0]])
+    unit_vectors = np.eye(2)
+
+    crs = ro.obj_LocalDepth3dCrs(
+        citation=ro.Citation(title="Test CRS", originator="pyetp-tester"),
+        vertical_crs=ro.VerticalUnknownCrs(unknown="MSL"),
+        projected_crs=ro.ProjectedCrsEpsgCode(epsg_code=23031),
+    )
+    epc = ro.obj_EpcExternalPartReference(
+        citation=ro.Citation(title="Test EPC", originator="pyetp-tester"),
+    )
+
+    # Case 1: regular surface with Z-values — supported.
+    regular_gri = ro.obj_Grid2dRepresentation.from_regular_surface(
+        citation=ro.Citation(title="Regular surface", originator="pyetp-tester"),
+        crs=crs,
+        epc_external_part_reference=epc,
+        shape=shape,
+        origin=origin,
+        spacing=spacing,
+        unit_vec_1=unit_vectors[:, 0],
+        unit_vec_2=unit_vectors[:, 1],
+    )
+    assert regular_gri.is_supported_regular_surface() is True
+
+    # Case 2: scaffold — geometry.points is a bare Point3dLatticeArray, no zvalues.
+    scaffold_gri = ro.obj_Grid2dRepresentation(
+        citation=ro.Citation(title="Scaffold", originator="pyetp-tester"),
+        surface_role=ro.SurfaceRole.MAP,
+        grid2d_patch=ro.Grid2dPatch(
+            patch_index=0,
+            slowest_axis_count=shape[0],
+            fastest_axis_count=shape[1],
+            geometry=ro.PointGeometry(
+                local_crs=ro.DataObjectReference.from_object(crs),
+                points=regular_gri.grid2d_patch.geometry.points.supporting_geometry,
+            ),
+        ),
+    )
+    assert scaffold_gri.is_supported_regular_surface() is False
+
+    # Case 3: unresolved Point3dFromRepresentationLatticeArray reference —
+    # has zvalues but the supporting_representation is still a
+    # DataObjectReference, so get_regular_surface_parameters would raise.
+    referencing_gri = ro.obj_Grid2dRepresentation(
+        citation=ro.Citation(title="Referencing", originator="pyetp-tester"),
+        surface_role=ro.SurfaceRole.MAP,
+        grid2d_patch=ro.Grid2dPatch(
+            patch_index=0,
+            slowest_axis_count=shape[0],
+            fastest_axis_count=shape[1],
+            geometry=ro.PointGeometry(
+                local_crs=ro.DataObjectReference.from_object(crs),
+                points=ro.Point3dZValueArray(
+                    supporting_geometry=ro.Point3dFromRepresentationLatticeArray(
+                        node_indices_on_supporting_representation=ro.IntegerLatticeArray(
+                            start_value=0,
+                            offset=[
+                                ro.IntegerConstantArray(value=1, count=shape[0] - 1),
+                                ro.IntegerConstantArray(value=1, count=shape[1] - 1),
+                            ],
+                        ),
+                        supporting_representation=ro.DataObjectReference.from_object(
+                            scaffold_gri
+                        ),
+                    ),
+                    zvalues=ro.DoubleHdf5Array(
+                        values=ro.Hdf5Dataset(
+                            path_in_hdf_file="/RESQML/test/zvalues",
+                            hdf_proxy=ro.DataObjectReference.from_object(epc),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+    assert referencing_gri.is_supported_regular_surface() is False
+
+    # After populate_data_references, the reference is resolved → supported.
+    model = RDDMSModel(
+        obj=referencing_gri,
+        arrays={},
+        linked_models=[RDDMSModel(obj=scaffold_gri, arrays={}, linked_models=[])],
+    )
+    populated = model.populate_data_references()
+    assert isinstance(populated, ro.obj_Grid2dRepresentation)
+    assert populated.is_supported_regular_surface() is True

--- a/tests/test_resqmlv201_objects.py
+++ b/tests/test_resqmlv201_objects.py
@@ -328,6 +328,24 @@ def test_regular_grid_2d_representation_from_angle() -> None:
         sg.offset[1].offset.coordinate2, np.cos(angle), atol=1e-10
     )
 
+    # Test yflip attribute for left-handed supports
+    gri_ref_left_handed = ro.obj_Grid2dRepresentation.from_regular_surface(
+        citation=citation,
+        crs=crs,
+        epc_external_part_reference=epc,
+        shape=shape,
+        origin=origin,
+        spacing=spacing,
+        unit_vec_1=unit_vec_2,
+        unit_vec_2=unit_vec_1,
+        uuid=gri.uuid,
+        path_in_hdf_file=gri.grid2d_patch.geometry.points.zvalues.values.path_in_hdf_file,  # type: ignore[attr-defined]
+    )
+    
+    assert not gri_ref.get_regular_surface_parameters().yflip
+    assert gri_ref_left_handed.get_regular_surface_parameters().yflip
+
+
 
 def test_rotated_regular_grid_2d_representation() -> None:
     # Here we compare the results of a rotated surface in three different

--- a/tests/test_resqmlv201_objects.py
+++ b/tests/test_resqmlv201_objects.py
@@ -341,10 +341,9 @@ def test_regular_grid_2d_representation_from_angle() -> None:
         uuid=gri.uuid,
         path_in_hdf_file=gri.grid2d_patch.geometry.points.zvalues.values.path_in_hdf_file,  # type: ignore[attr-defined]
     )
-    
+
     assert not gri_ref.get_regular_surface_parameters().yflip
     assert gri_ref_left_handed.get_regular_surface_parameters().yflip
-
 
 
 def test_rotated_regular_grid_2d_representation() -> None:


### PR DESCRIPTION
## Summary

Adds a new helper method `is_supported_regular_surface()` to `obj_Grid2dRepresentation`. It returns `True` only when the grid has Z-values **and** a subsequent call to `get_regular_surface_parameters()` is expected to succeed — letting callers cheaply pre-check a surface before trying to load it.

Add a `yflip` parameter to RegularSurfaceParameters, which is set when we deal with left-handed support geometries.  Adds also a helper function to Point3dLatticeArray that identifies the handedness (from the unit vector order); adds relevant test


## Why

While building the RDDMS surfaces viewer against `dsif-orchastrator/default`, two of the six surfaces (`ST15M04_VEL`, `CGG19002`) caused a runtime crash:
'Point3dLatticeArray' object has no attribute 'zvalues'

These are *scaffold* surfaces — their `geometry.points` is a bare `Point3dLatticeArray` with no Z-values. They exist only to define the 2D grid that other Landmark surfaces (Kolje, Knurr, Nordmela, Fuglen) reference via `Point3dFromRepresentationLatticeArray.supporting_representation`.

The viewer (and any other consumer) currently has to type-check `geometry.points` itself before reading `.zvalues`. This PR pushes that knowledge down into resqml_objects so callers get a single boolean check instead.

Even though rddms_io will not write left-handed supporting geometries, we have observed these in the wild, written by other tools.

## Changes

### `src/resqml_objects/v201/generated.py`

Added `is_supported_regular_surface()` on `obj_Grid2dRepresentation`. Logic:

1. Quick check that `geometry.points` is a `Point3dZValueArray` — filters out scaffold surfaces.
2. Try `get_regular_surface_parameters()` in a try/except — catches every other failure mode (`NotImplementedError` for unsupported point types, `ValueError` for unresolved `Point3dFromRepresentationLatticeArray` references, `AttributeError` for unexpected shapes).

Returns `False` for:
- Scaffold surfaces (`Point3dLatticeArray` directly).
- Landmark surfaces whose `supporting_representation` hasn't been resolved yet (call `RDDMSModel.populate_data_references()` first).
- Surfaces with non-`DoubleConstantArray` offset spacing.
- Anything `get_regular_surface_parameters()` can't handle.

### `tests/test_resqmlv201_objects.py`

Added `test_is_supported_regular_surface` covering all four states:

| Case | Expected |
|---|---|
| Regular surface (`Point3dZValueArray` + `Point3dLatticeArray` supporting_geometry) | `True` |
| Scaffold (`Point3dLatticeArray` directly, no Z-values) | `False` |
| Landmark with unresolved `supporting_representation` (still a `DataObjectReference`) | `False` |
| Same Landmark after `populate_data_references()` | `True` |
