### PR TITLE
Add Faults data type and refactor polyline-set decoding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "xsdata >= 25.4",
     "fastavro>=1.12.1",
     "h5py>=3.16.0",
+    "geojson>=3.2.0",
 ]
 
 [project.urls]

--- a/src/resqml_objects/v201/generated.py
+++ b/src/resqml_objects/v201/generated.py
@@ -16,8 +16,10 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Annotated, Any, Self, Type
 
+import geojson
 import numpy as np
 import numpy.typing as npt
+from typing_extensions import override
 from xsdata.models.datatype import XmlDate, XmlDateTime, XmlPeriod
 
 from resqml_objects.data_types import RegularSurfaceParameters
@@ -6496,6 +6498,30 @@ class AbstractPoint3dArray:
 
     class Meta:
         target_namespace = "http://www.energistics.org/energyml/data/resqmlv2"
+
+    def to_numpy(
+        self, arrays: dict[str, npt.NDArray[Any]]
+    ) -> "npt.NDArray[np.float64]":
+        """Decode this 3D-point array to an ``(N, 3)`` float64 array.
+
+        Subclasses provide the actual load; this base then enforces the
+        ``(N, 3)`` shape so every caller can rely on it.
+        """
+        arr = self._load_numpy(arrays)
+        if arr.ndim != 2 or arr.shape[-1] != 3:
+            raise ValueError(
+                f"Expected {type(self).__name__} to decode to (N, 3); "
+                f"got shape {arr.shape}"
+            )
+        return arr
+
+    def _load_numpy(
+        self, arrays: dict[str, npt.NDArray[Any]]
+    ) -> "npt.NDArray[np.float64]":
+        raise NotImplementedError(
+            f"3D-point array type {type(self).__name__} is not supported "
+            f"(only Point3dHdf5Array)."
+        )
 
 
 @dataclass(slots=True, kw_only=True)
@@ -13579,6 +13605,15 @@ class AbstractBooleanArray(AbstractValueArray):
     class Meta:
         target_namespace = "http://www.energistics.org/energyml/data/resqmlv2"
 
+    def to_numpy(self, arrays: dict[str, npt.NDArray[Any]]) -> "npt.NDArray[np.bool_]":
+        """Decode this boolean array to a flat ``bool`` numpy array.
+
+        Subclasses override.
+        """
+        raise NotImplementedError(
+            f"Unsupported AbstractBooleanArray subclass: {type(self).__name__}"
+        )
+
 
 @dataclass(slots=True, kw_only=True)
 class AbstractContactInterpretationPart:
@@ -13653,6 +13688,15 @@ class AbstractIntegerArray(AbstractValueArray):
 
     class Meta:
         target_namespace = "http://www.energistics.org/energyml/data/resqmlv2"
+
+    def to_numpy(self, arrays: dict[str, npt.NDArray[Any]]) -> "npt.NDArray[np.int64]":
+        """Decode this integer array to a flat ``int64`` numpy array.
+
+        Subclasses override.
+        """
+        raise TypeError(
+            f"Unsupported AbstractIntegerArray subclass: {type(self).__name__}"
+        )
 
 
 @dataclass(slots=True, kw_only=True)
@@ -15774,6 +15818,10 @@ class BooleanConstantArray(AbstractBooleanArray):
         }
     )
 
+    @override
+    def to_numpy(self, arrays: dict[str, npt.NDArray[Any]]) -> "npt.NDArray[np.bool_]":
+        return np.full(int(self.count), bool(self.value), dtype=np.bool_)
+
 
 @dataclass(slots=True, kw_only=True)
 class BooleanHdf5Array(AbstractBooleanArray):
@@ -15797,6 +15845,17 @@ class BooleanHdf5Array(AbstractBooleanArray):
             "required": True,
         }
     )
+
+    @override
+    def to_numpy(self, arrays: dict[str, npt.NDArray[Any]]) -> "npt.NDArray[np.bool_]":
+        path = self.values.path_in_hdf_file
+        if path not in arrays:
+            raise KeyError(
+                f"BooleanHdf5Array references HDF5 path {path!r} which is "
+                f"not in the supplied arrays dict (have: "
+                f"{sorted(arrays.keys())!r})"
+            )
+        return np.asarray(arrays[path], dtype=np.bool_)
 
 
 @dataclass(slots=True, kw_only=True)
@@ -16433,6 +16492,10 @@ class IntegerConstantArray(AbstractIntegerArray):
         }
     )
 
+    @override
+    def to_numpy(self, arrays: dict[str, npt.NDArray[Any]]) -> "npt.NDArray[np.int64]":
+        return np.full(int(self.count), int(self.value), dtype=np.int64)
+
 
 @dataclass(slots=True, kw_only=True)
 class IntegerHdf5Array(AbstractIntegerArray):
@@ -16467,6 +16530,23 @@ class IntegerHdf5Array(AbstractIntegerArray):
             "required": True,
         }
     )
+
+    @override
+    def to_numpy(self, arrays: dict[str, npt.NDArray[Any]]) -> "npt.NDArray[np.int64]":
+        path = self.values.path_in_hdf_file
+        if path not in arrays:
+            raise KeyError(
+                f"IntegerHdf5Array references HDF5 path {path!r} which is "
+                f"not in the supplied arrays dict (have: "
+                f"{sorted(arrays.keys())!r})"
+            )
+        raw = arrays[path]
+        if not np.issubdtype(np.asarray(raw).dtype, np.integer):
+            raise TypeError(
+                f"IntegerHdf5Array at {path!r} expects an integer dtype; "
+                f"got {np.asarray(raw).dtype}."
+            )
+        return np.asarray(raw, dtype=np.int64)
 
 
 @dataclass(slots=True, kw_only=True)
@@ -17050,6 +17130,19 @@ class Point3dHdf5Array(AbstractPoint3dArray):
             "required": True,
         }
     )
+
+    @override
+    def _load_numpy(
+        self, arrays: dict[str, npt.NDArray[Any]]
+    ) -> "npt.NDArray[np.float64]":
+        path = self.coordinates.path_in_hdf_file
+        if path not in arrays:
+            raise KeyError(
+                f"Point3dHdf5Array references HDF5 path {path!r} which is "
+                f"not in the supplied arrays dict (have: "
+                f"{sorted(arrays.keys())!r})"
+            )
+        return np.asarray(arrays[path], dtype=np.float64)
 
 
 @dataclass(slots=True, kw_only=True)
@@ -19851,6 +19944,215 @@ class AbstractLocal3dCrs(AbstractResqmlDataObject):
         }
     )
 
+    _BOUND_PROJECTED_RE = re.compile(
+        r"BoundProjected:EPSG::(?P<projected>\d+)_EPSG::(?P<vertical>\d+)"
+    )
+    _TITLE_EPSG_RE = re.compile(r"P(?P<projected>\d+)_T(?P<vertical>\d+)")
+    _PLAIN_EPSG_RE = re.compile(r"EPSG::?(?P<code>\d+)")
+    _WKT_RE = re.compile(r"\b(?:PROJCS|PROJCRS|GEOGCS|GEOGCRS|COMPD_CS|COMPOUNDCRS)\[")
+
+    def _find_epsg_and_source(self) -> tuple[int | None, int | None, str | None]:
+        """Private: like ``get_epsg_code`` but also returns the vertical EPSG
+        (when the matching source provides one) and the source tag.
+
+        Returns ``(projected_epsg, vertical_epsg, source)``. All None when
+        nothing matched. ``vertical_epsg`` is only populated for sources that
+        carry both codes (ProjectedCrsEpsgCode+VerticalCrsEpsgCode,
+        BoundProjected pattern, or ``P<n>_T<n>`` title pattern).
+        """
+        if isinstance(self.projected_crs, ProjectedCrsEpsgCode):
+            proj = int(self.projected_crs.epsg_code)
+            vert = (
+                int(self.vertical_crs.epsg_code)
+                if isinstance(self.vertical_crs, VerticalCrsEpsgCode)
+                else None
+            )
+            return proj, vert, "projected_crs"
+
+        unknown_text = ""
+        if isinstance(self.projected_crs, ProjectedUnknownCrs):
+            unknown_text = (self.projected_crs.unknown or "").strip()
+        extra_blob = " ".join(
+            f"{nv.name}={nv.value}" for nv in (self.extra_metadata or [])
+        )
+        title = self.citation.title or ""
+
+        cls = AbstractLocal3dCrs
+        bp = cls._BOUND_PROJECTED_RE.search(
+            extra_blob
+        ) or cls._BOUND_PROJECTED_RE.search(unknown_text)
+        if bp:
+            return (
+                int(bp.group("projected")),
+                int(bp.group("vertical")),
+                "extra_metadata",
+            )
+
+        tm = cls._TITLE_EPSG_RE.search(title)
+        if tm:
+            return (
+                int(tm.group("projected")),
+                int(tm.group("vertical")),
+                "citation_title",
+            )
+
+        plain = cls._PLAIN_EPSG_RE.search(extra_blob) or cls._PLAIN_EPSG_RE.search(
+            unknown_text
+        )
+        if plain:
+            return int(plain.group("code")), None, "extra_metadata"
+
+        return None, None, None
+
+    def _find_wkt_and_source(self) -> tuple[str | None, str | None]:
+        """Private: like ``get_wkt`` but also returns the source tag.
+
+        Returns ``(wkt, source)``. Both None when no WKT is found.
+        """
+        cls = AbstractLocal3dCrs
+
+        if isinstance(self.projected_crs, ProjectedUnknownCrs):
+            unknown_text = (self.projected_crs.unknown or "").strip()
+            if cls._WKT_RE.search(unknown_text):
+                return unknown_text, "projected_crs.unknown"
+
+        for nv in self.extra_metadata or []:
+            v = nv.value or ""
+            if cls._WKT_RE.search(v):
+                return v.strip(), "extra_metadata"
+
+        title = self.citation.title or ""
+        if cls._WKT_RE.search(title):
+            return title, "citation.title"
+
+        return None, None
+
+    def get_epsg_code(self) -> int | None:
+        """Return the projected EPSG code if findable, else None.
+
+        Tries each storage shape we've seen in RDDMS, in priority order:
+
+        1. ``ProjectedCrsEpsgCode.epsg_code`` — the RESQML-correct shape.
+        2. ``BoundProjected:EPSG::P_EPSG::V`` pattern in ``extra_metadata``
+           or in ``ProjectedUnknownCrs.unknown``.
+        3. ``P<n>_T<n>`` pattern in ``citation.title`` (OW-style).
+        4. Plain ``EPSG::<n>`` substring in ``extra_metadata`` or
+           ``ProjectedUnknownCrs.unknown``.
+
+        Returns ``None`` if no EPSG code is recoverable from any of these.
+        """
+        proj, _vert, _source = self._find_epsg_and_source()
+        return proj
+
+    def get_wkt(self) -> str | None:
+        """Return a WKT string if literally stored on this CRS, else None.
+
+        Looks in (in order):
+
+        1. ``ProjectedUnknownCrs.unknown``
+        2. Each ``extra_metadata`` entry's value
+        3. ``citation.title``
+        """
+        wkt, _source = self._find_wkt_and_source()
+        return wkt
+
+    def is_time_domain(self) -> bool:
+        """True if this CRS is a time-domain CRS (``obj_LocalTime3dCrs``)."""
+        return isinstance(self, obj_LocalTime3dCrs)
+
+    def is_depth_domain(self) -> bool:
+        """True if this CRS is a depth-domain CRS (``obj_LocalDepth3dCrs``)."""
+        return isinstance(self, obj_LocalDepth3dCrs)
+
+    def _resolve_crs(self) -> dict:
+        """Resolve this local-3d-CRS into a flat dict of raw fields.
+
+        Handles all four CRS-storage variants observed in RDDMS:
+
+        1. ``ProjectedCrsEpsgCode`` (RESQML-correct shape).
+        2. ``ProjectedUnknownCrs`` + ``extra_metadata`` carrying
+           ``BoundProjected:EPSG::P_EPSG::V``.
+        3. ``PROJCS[...]`` / ``PROJCRS[...]`` WKT blob anywhere.
+        4. OW-style name like ``ST_ED50_UTM32N_P23231_T2233``.
+
+        Returns a dict with always-present keys:
+
+        - ``name``: human-readable identifier (urn:..., WKT title, OW name,
+          or ``"unknown"``)
+        - ``z_domain``: ``"depth"`` or ``"time"``
+        - ``projected_uom``, ``vertical_uom``, ``crs_uuid``,
+          ``crs_citation_title``
+
+        Optional keys (only set when resolved):
+        ``projected_epsg_code``, ``vertical_epsg_code``, ``wkt``,
+        ``unknown_name``, ``source``.
+
+        The caller is responsible for shaping these fields into whatever
+        downstream format it needs (GeoJSON ``crs`` block, OGC URN string,
+        etc.).
+        """
+        info: dict = {
+            "z_domain": "time" if self.is_time_domain() else "depth",
+            "projected_uom": self.projected_uom.value,
+            "vertical_uom": self.vertical_uom.value,
+            "crs_uuid": self.uuid,
+            "crs_citation_title": self.citation.title,
+        }
+
+        proj_epsg: int | None = None
+        vert_epsg: int | None = None
+        wkt: str | None = None
+        ow_name: str | None = None
+        source: str | None = None
+
+        # Priority: epsg-proper > wkt > epsg-in-extra > ow-name > truly-unknown.
+        if isinstance(self.projected_crs, ProjectedCrsEpsgCode):
+            proj_epsg, vert_epsg, source = self._find_epsg_and_source()
+        else:
+            wkt, source = self._find_wkt_and_source()
+            if wkt is None:
+                proj_epsg, vert_epsg, source = self._find_epsg_and_source()
+                if proj_epsg is None:
+                    # Last-resort fallback: surface any free-form text as a name.
+                    unknown_text = ""
+                    if isinstance(self.projected_crs, ProjectedUnknownCrs):
+                        unknown_text = (self.projected_crs.unknown or "").strip()
+                    title = self.citation.title or ""
+                    if unknown_text or title:
+                        ow_name = unknown_text or title
+                        source = (
+                            "projected_crs.unknown"
+                            if unknown_text
+                            else "citation.title"
+                        )
+
+        if proj_epsg is not None:
+            info["projected_epsg_code"] = proj_epsg
+        if vert_epsg is not None:
+            info["vertical_epsg_code"] = vert_epsg
+        if wkt is not None:
+            info["wkt"] = wkt
+        if ow_name is not None:
+            info["unknown_name"] = ow_name
+        if source is not None:
+            info["source"] = source
+
+        if proj_epsg is not None:
+            name = f"urn:ogc:def:crs:EPSG::{proj_epsg}"
+        elif wkt is not None:
+            projcs_match = re.search(
+                r'(?:PROJCS|PROJCRS|GEOGCS|GEOGCRS|COMPD_CS|COMPOUNDCRS)\["([^"]+)"',
+                wkt,
+            )
+            name = projcs_match.group(1) if projcs_match else wkt
+        elif ow_name is not None:
+            name = ow_name
+        else:
+            name = "unknown"
+        info["name"] = name
+
+        return info
+
 
 @dataclass(slots=True, kw_only=True)
 class AbstractParentWindow:
@@ -20473,6 +20775,35 @@ class PolylineSetPatch(Patch):
             "required": True,
         }
     )
+
+    def decode(
+        self,
+        arrays: dict[str, npt.NDArray[Any]],
+    ) -> "tuple[npt.NDArray[np.float64], npt.NDArray[np.int64], npt.NDArray[np.bool_]]":
+        """Decode this patch's HDF5 geometry into ``(points, node_counts, closed)``.
+
+        - ``points``: ``(N, 3)`` float64 — concatenated XYZ for every polyline.
+        - ``node_counts``: ``(n_polylines,)`` int64 — how many rows of ``points``
+          belong to each polyline.
+        - ``closed``: ``(n_polylines,)`` bool — whether each polyline loops back.
+
+        Falls back to all-False for ``closed_polylines`` if the underlying
+        boolean array is a subclass we don't recognise (real fault sticks are
+        virtually never closed, so this is safe).
+        """
+        points = self.geometry.points.to_numpy(arrays)
+        node_counts = self.node_count_per_polyline.to_numpy(arrays)
+        if int(node_counts.sum()) != len(points):
+            raise ValueError(
+                f"Patch {self.patch_index}: node_count_per_polyline sums "
+                f"to {int(node_counts.sum())} but the points array has "
+                f"{len(points)} rows."
+            )
+        try:
+            closed = self.closed_polylines.to_numpy(arrays)
+        except NotImplementedError:
+            closed = np.zeros(len(node_counts), dtype=np.bool_)
+        return points, node_counts, closed
 
 
 @dataclass(slots=True, kw_only=True)
@@ -22317,6 +22648,102 @@ class obj_PolylineSetRepresentation(AbstractRepresentation):
             "min_occurs": 1,
         },
     )
+
+    def get_geojson(
+        self,
+        arrays: dict[str, npt.NDArray[Any]],
+        crs: "AbstractLocal3dCrs | None" = None,
+        *,
+        extra_properties: dict | None = None,
+        name: str | None = None,
+    ):
+        """Convert this polyline set to a GeoJSON ``FeatureCollection``.
+
+        Walks the polyline-set's HDF5 geometry via ``patch.decode(arrays)``
+        and resolves the CRS via ``crs._resolve_crs()``, emitting one
+        ``LineString`` Feature per polyline. Coordinates stay in the source
+        CRS
+
+        Parameters
+        ----------
+        arrays
+            Dict of ``path_in_hdf_file -> numpy array``, typically
+            ``RDDMSModel.arrays``.
+        crs
+            The linked CRS (``obj_LocalDepth3dCrs`` or ``obj_LocalTime3dCrs``).
+            If ``None`` the FeatureCollection will have no ``crs`` block.
+        extra_properties
+            Optional mapping copied into every emitted Feature (e.g.
+            fault interpretation title/uuid).
+        name
+            Optional ``name`` for the FeatureCollection (default: this
+            polyline-set's citation title).
+
+        Returns
+        -------
+        geojson.FeatureCollection
+        """
+        if crs is None:
+            crs_block: dict | None = None
+        else:
+            info = crs._resolve_crs()
+            crs_name = info["name"]
+            # `crs_uuid` is a RESQML identifier; not useful in the GeoJSON
+            # crs block. `name` is hoisted to the top of the properties.
+            excluded = {"name", "crs_uuid"}
+            block_props = {k: v for k, v in info.items() if k not in excluded}
+            crs_block = {
+                "type": "name",
+                "properties": {"name": crs_name, **block_props},
+            }
+
+        features: list = []
+        polyline_index = 0
+        for patch in self.line_patch:
+            points, node_counts, closed = patch.decode(arrays)
+            cursor = 0
+            for i_in_patch, n in enumerate(node_counts):
+                idx = polyline_index
+                polyline_index += 1
+                n_int = int(n)
+                slice_pts = points[cursor : cursor + n_int]
+                cursor += n_int
+
+                if n_int < 2:
+                    continue
+
+                coords = [[float(x) for x in row] for row in slice_pts]
+                is_closed = bool(closed[i_in_patch])
+                if is_closed and coords[0] != coords[-1]:
+                    coords = coords + [list(coords[0])]
+
+                properties: dict = {
+                    "polyline_index": idx,
+                    "node_count": n_int,
+                    "closed": is_closed,
+                }
+                if extra_properties:
+                    properties.update(extra_properties)
+
+                features.append(
+                    geojson.Feature(
+                        geometry=geojson.LineString(coords),
+                        properties=properties,
+                    )
+                )
+
+        fc = geojson.FeatureCollection(features)
+        if name is not None:
+            fc["name"] = name
+        elif self.citation and self.citation.title:
+            fc["name"] = self.citation.title
+        if crs_block is not None:
+            fc["crs"] = crs_block
+        fc["properties"] = {
+            "polyline_set_uuid": self.uuid,
+            "polyline_count": len(features),
+        }
+        return fc
 
 
 @dataclass(slots=True, kw_only=True)

--- a/tests/test_geojson_export.py
+++ b/tests/test_geojson_export.py
@@ -1,0 +1,490 @@
+from __future__ import annotations
+
+import uuid as uuid_lib
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+import resqml_objects.v201 as ro
+
+
+def polyline_set_to_geojson(
+    polyline_set, arrays, crs=None, *, extra_properties=None, name=None
+):
+    return polyline_set.get_geojson(
+        arrays, crs, extra_properties=extra_properties, name=name
+    )
+
+
+def get_random_crs(
+    *,
+    domain: str = "depth",
+    projected_crs: ro.AbstractProjectedCrs | None = None,
+    vertical_crs: ro.AbstractVerticalCrs | None = None,
+    title: str = "Random fault CRS",
+    extra_metadata: list[ro.NameValuePair] | None = None,
+) -> ro.AbstractLocal3dCrs:
+    """Build a LocalDepth3dCrs (default) or LocalTime3dCrs for tests.
+
+    All keyword arguments optional — override them when a
+    test needs a specific CRS shape (e.g. EPSG-in-extra-metadata).
+    """
+
+    base_kwargs: dict = dict(
+        citation=ro.Citation(title=title, originator="geojson-tester"),
+        projected_crs=projected_crs
+        or ro.ProjectedUnknownCrs(unknown="No EPSG code specified"),
+        vertical_crs=vertical_crs
+        or ro.VerticalUnknownCrs(unknown="No EPSG code specified"),
+        vertical_uom=ro.LengthUom.M,
+    )
+    if extra_metadata is not None:
+        base_kwargs["extra_metadata"] = extra_metadata
+
+    if domain == "depth":
+        return ro.obj_LocalDepth3dCrs(**base_kwargs)
+    return ro.obj_LocalTime3dCrs(**base_kwargs, time_uom=ro.TimeUom.MS)
+
+
+def get_random_polyline_set(
+    *,
+    crs: ro.obj_LocalDepth3dCrs | None = None,
+    node_counts: list[int] | None = None,
+    closed: bool | list[bool] = False,
+    points: npt.NDArray[np.float64] | None = None,
+    title: str = "Random fault polyline-set",
+) -> tuple[
+    ro.AbstractLocal3dCrs,
+    ro.obj_EpcExternalPartReference,
+    ro.obj_PolylineSetRepresentation,
+    dict[str, npt.NDArray[np.float64]],
+]:
+    """Build a random synthetic polyline-set for tests.
+
+    All keyword arguments optional:
+
+    * ``crs``         — pass to use a specific CRS shape; defaults to a fresh
+                       epsg-proper CRS.
+    * ``node_counts`` — list giving the size of each polyline; defaults to a
+                       random number of polylines, all the same random length.
+    * ``closed``      — single bool for all, or a per-polyline list; defaults
+                       to all-False (typical fault sticks).
+    * ``points``      — pre-built ``(N_total, 3)`` array; defaults to random.
+                       Pass when an assertion needs deterministic coordinates.
+    * ``title``       — citation title of the polyline-set.
+
+    Returns ``(crs, epc, polyline_set, arrays)``.
+    """
+    # Decide polyline counts.
+    if node_counts is None:
+        n_polylines = int(np.random.randint(2, 6))
+        nodes_per = int(np.random.randint(3, 8))
+        node_counts_arr = np.full(n_polylines, nodes_per, dtype=np.int64)
+    else:
+        node_counts_arr = np.asarray(node_counts, dtype=np.int64)
+        n_polylines = int(node_counts_arr.shape[0])
+    n_total = int(node_counts_arr.sum())
+
+    # Decide points.
+    if points is None:
+        points = np.random.rand(n_total, 3) * 1000.0
+    else:
+        assert points.shape == (n_total, 3), (
+            f"points shape {points.shape} doesn't match node_counts sum {n_total}"
+        )
+
+    # Decide closed flags.
+    if isinstance(closed, bool):
+        closed_arr = np.full(n_polylines, closed, dtype=np.bool_)
+    else:
+        closed_arr = np.asarray(closed, dtype=np.bool_)
+        assert closed_arr.shape == (n_polylines,)
+
+    # Default CRS: epsg-proper.
+    if crs is None:
+        crs = get_random_crs(
+            projected_crs=ro.ProjectedCrsEpsgCode(epsg_code=23031),
+            vertical_crs=ro.VerticalCrsEpsgCode(epsg_code=5715),
+        )
+
+    epc = ro.obj_EpcExternalPartReference(
+        citation=ro.Citation(title="Random epc", originator="geojson-tester"),
+    )
+
+    arrays: dict[str, npt.NDArray] = {}
+
+    # node_count_per_polyline: use ConstantArray when all values agree, else HDF5.
+    if len(set(node_counts_arr.tolist())) == 1:
+        node_count_array: ro.AbstractIntegerArray = ro.IntegerConstantArray(
+            value=int(node_counts_arr[0]), count=n_polylines
+        )
+    else:
+        nc_path = f"/RESQML/{uuid_lib.uuid4()}/node_counts"
+        node_count_array = ro.IntegerHdf5Array(
+            null_value=-1,
+            values=ro.Hdf5Dataset(
+                path_in_hdf_file=nc_path,
+                hdf_proxy=ro.DataObjectReference.from_object(epc),
+            ),
+        )
+        arrays[nc_path] = node_counts_arr
+
+    # closed_polylines: use ConstantArray when all values agree, else HDF5.
+    if len(set(closed_arr.tolist())) == 1:
+        closed_array: ro.AbstractBooleanArray = ro.BooleanConstantArray(
+            value=bool(closed_arr[0]), count=n_polylines
+        )
+    else:
+        cl_path = f"/RESQML/{uuid_lib.uuid4()}/closed"
+        closed_array = ro.BooleanHdf5Array(
+            values=ro.Hdf5Dataset(
+                path_in_hdf_file=cl_path,
+                hdf_proxy=ro.DataObjectReference.from_object(epc),
+            ),
+        )
+        arrays[cl_path] = closed_arr
+
+    # Build the patch.
+    points_path = f"/RESQML/{uuid_lib.uuid4()}/points"
+    patch = ro.PolylineSetPatch(
+        patch_index=0,
+        closed_polylines=closed_array,
+        node_count_per_polyline=node_count_array,
+        geometry=ro.PointGeometry(
+            local_crs=ro.DataObjectReference.from_object(crs),
+            points=ro.Point3dHdf5Array(
+                coordinates=ro.Hdf5Dataset(
+                    path_in_hdf_file=points_path,
+                    hdf_proxy=ro.DataObjectReference.from_object(epc),
+                ),
+            ),
+        ),
+    )
+
+    pls = ro.obj_PolylineSetRepresentation(
+        citation=ro.Citation(title=title, originator="geojson-tester"),
+        line_role=ro.LineRole.INTERPRETATION_LINE,
+        line_patch=[patch],
+    )
+    arrays[points_path] = points
+
+    return crs, epc, pls, arrays
+
+
+def test_resolve_crs_epsg_proper():
+    crs = get_random_crs(
+        projected_crs=ro.ProjectedCrsEpsgCode(epsg_code=23031),
+        vertical_crs=ro.VerticalCrsEpsgCode(epsg_code=5715),
+    )
+    info = crs._resolve_crs()
+    assert info["projected_epsg_code"] == 23031
+    assert info["vertical_epsg_code"] == 5715
+    assert info["source"] == "projected_crs"
+    assert info["name"] == "urn:ogc:def:crs:EPSG::23031"
+    assert info["z_domain"] == "depth"
+
+
+# Synthetic CRS identifiers used throughout the variant tests below.
+# They preserve the structural patterns the regexes need (P<n>_T<n>,
+# BoundProjected:EPSG::P_EPSG::V, PROJCS["…"])
+_TEST_PROJ_EPSG = 32633
+_TEST_VERT_EPSG = 5773
+_TEST_CRS_TITLE_WITH_PT = f"TEST_CRS_P{_TEST_PROJ_EPSG}_T{_TEST_VERT_EPSG}"
+_TEST_BOUND_PROJECTED = (
+    f"BoundProjected:EPSG::{_TEST_PROJ_EPSG}_EPSG::{_TEST_VERT_EPSG}"
+)
+
+
+def test_resolve_crs_epsg_in_extra_metadata():
+    """ProjectedUnknownCrs + extra_metadata carrying a
+    ``BoundProjected:EPSG::P_EPSG::V`` string — proper CRS fields are
+    unknown, but the EPSG codes are recoverable from the extra_metadata.
+    """
+    crs = get_random_crs(
+        domain="time",
+        title=_TEST_CRS_TITLE_WITH_PT,
+        extra_metadata=[ro.NameValuePair(name="crs", value=_TEST_BOUND_PROJECTED)],
+    )
+    info = crs._resolve_crs()
+    assert info["projected_epsg_code"] == _TEST_PROJ_EPSG
+    assert info["vertical_epsg_code"] == _TEST_VERT_EPSG
+    assert info["source"] == "extra_metadata"
+    assert info["name"] == f"urn:ogc:def:crs:EPSG::{_TEST_PROJ_EPSG}"
+    assert info["z_domain"] == "time"
+
+
+def test_resolve_crs_epsg_only_in_citation_title():
+    """If extra_metadata is absent but the citation title carries the
+    ``P<digits>_T<digits>`` pattern, we should still recover it.
+    """
+    crs = get_random_crs(title=_TEST_CRS_TITLE_WITH_PT)
+    info = crs._resolve_crs()
+    assert info["projected_epsg_code"] == _TEST_PROJ_EPSG
+    assert info["vertical_epsg_code"] == _TEST_VERT_EPSG
+    assert info["source"] == "citation_title"
+
+
+def test_resolve_crs_wkt_string():
+    """WKT supplied as the projected_crs.unknown text."""
+    wkt = (
+        'PROJCS["Test Projected CRS",GEOGCS["Test Geographic CRS",'
+        'DATUM["Test_Datum",SPHEROID["Test Spheroid",6378137,298.257223563]]],'
+        'PROJECTION["Transverse_Mercator"],UNIT["metre",1]]'
+    )
+    crs = get_random_crs(projected_crs=ro.ProjectedUnknownCrs(unknown=wkt))
+    info = crs._resolve_crs()
+    assert info["wkt"] == wkt
+    assert info["source"] == "projected_crs.unknown"
+    assert info["name"] == "Test Projected CRS"
+
+
+def test_resolve_crs_wkt_in_extra_metadata_captures_just_value():
+    """When WKT is in extra_metadata alongside unrelated entries (project
+    metadata, ingest tool tags, etc.), the captured ``wkt`` must be just
+    the value of the WKT entry — no leading junk from the joined blob.
+    """
+    wkt = (
+        'PROJCS["Test UTM Zone",GEOGCS["Test Geo CRS",'
+        'DATUM["Test_Datum",SPHEROID["Test Spheroid",6378137,298.257223563]]],'
+        'PROJECTION["Transverse_Mercator"],UNIT["metre",1]]'
+    )
+    unrelated_value = str(uuid_lib.uuid4())
+    crs = get_random_crs(
+        projected_crs=ro.ProjectedUnknownCrs(unknown="WKT"),
+        extra_metadata=[
+            # Unrelated metadata entry — the extractor must ignore it.
+            ro.NameValuePair(name="unrelated_metadata", value=unrelated_value),
+            # The real WKT entry — the extractor must pick THIS value.
+            ro.NameValuePair(name="projected_crs_wkt", value=wkt),
+        ],
+    )
+    info = crs._resolve_crs()
+    assert info["wkt"] == wkt
+    assert "unrelated_metadata" not in info["wkt"]
+    assert unrelated_value not in info["wkt"]
+    assert info["source"] == "extra_metadata"
+    assert info["name"] == "Test UTM Zone"
+
+
+def test_resolve_crs_ow_style_name():
+    """ProjectedUnknownCrs whose ``unknown`` holds a name-like string
+    with no EPSG digits or WKT pattern. We just surface it as
+    ``unknown_name``.
+    """
+    crs = get_random_crs(
+        projected_crs=ro.ProjectedUnknownCrs(unknown="TEST_CRS_NAME_OW_STYLE"),
+        title="some-crs",
+    )
+    info = crs._resolve_crs()
+    assert info["unknown_name"] == "TEST_CRS_NAME_OW_STYLE"
+    assert info["name"] == "TEST_CRS_NAME_OW_STYLE"
+
+
+# -----------------------------------------------------------------------------
+# Naive helpers — get_epsg_code / get_wkt / is_time_domain / is_depth_domain
+# -----------------------------------------------------------------------------
+
+
+def test_get_epsg_code_epsg_proper():
+    crs = get_random_crs(projected_crs=ro.ProjectedCrsEpsgCode(epsg_code=23031))
+    assert crs.get_epsg_code() == 23031
+
+
+def test_get_epsg_code_bound_projected_in_extra_metadata():
+    crs = get_random_crs(
+        extra_metadata=[ro.NameValuePair(name="crs", value=_TEST_BOUND_PROJECTED)],
+    )
+    assert crs.get_epsg_code() == _TEST_PROJ_EPSG
+
+
+def test_get_epsg_code_from_citation_title_pattern():
+    crs = get_random_crs(title=_TEST_CRS_TITLE_WITH_PT)
+    assert crs.get_epsg_code() == _TEST_PROJ_EPSG
+
+
+def test_get_epsg_code_none_when_truly_unknown():
+    crs = get_random_crs()  # ProjectedUnknownCrs, default title, no extras
+    assert crs.get_epsg_code() is None
+
+
+def test_get_wkt_from_projected_unknown():
+    wkt = 'PROJCS["TestCRS",GEOGCS["g",DATUM["d",SPHEROID["s",6378137,298.257]]]]'
+    crs = get_random_crs(projected_crs=ro.ProjectedUnknownCrs(unknown=wkt))
+    assert crs.get_wkt() == wkt
+
+
+def test_get_wkt_from_extra_metadata():
+    wkt = 'PROJCS["Other",GEOGCS["g",DATUM["d",SPHEROID["s",6378137,298.257]]]]'
+    crs = get_random_crs(
+        extra_metadata=[
+            ro.NameValuePair(name="unrelated", value="just a tag"),
+            ro.NameValuePair(name="projected_crs_wkt", value=wkt),
+        ],
+    )
+    assert crs.get_wkt() == wkt
+
+
+def test_get_wkt_none_when_only_epsg_code():
+    """Naive accessor: do NOT synthesise WKT from an EPSG code."""
+    crs = get_random_crs(projected_crs=ro.ProjectedCrsEpsgCode(epsg_code=23031))
+    assert crs.get_epsg_code() == 23031
+    assert crs.get_wkt() is None
+
+
+def test_is_time_and_depth_domain_are_exclusive():
+    depth = get_random_crs(domain="depth")
+    time = get_random_crs(domain="time")
+
+    assert depth.is_depth_domain() is True
+    assert depth.is_time_domain() is False
+
+    assert time.is_time_domain() is True
+    assert time.is_depth_domain() is False
+
+
+def test_polyline_set_single_polyline_no_crs():
+    _, _, pls, arrays = get_random_polyline_set(node_counts=[5])
+    fc = polyline_set_to_geojson(pls, arrays, crs=None)
+
+    assert fc["type"] == "FeatureCollection"
+    assert "crs" not in fc
+    assert fc["properties"]["polyline_count"] == 1
+    assert fc["name"] == "Random fault polyline-set"
+
+    feat = fc["features"][0]
+    assert feat["geometry"]["type"] == "LineString"
+    assert len(feat["geometry"]["coordinates"]) == 5
+    points_path = pls.line_patch[0].geometry.points.coordinates.path_in_hdf_file
+    np.testing.assert_allclose(
+        feat["geometry"]["coordinates"], arrays[points_path], atol=1e-5
+    )
+    assert feat["properties"]["polyline_index"] == 0
+    assert feat["properties"]["node_count"] == 5
+    assert feat["properties"]["closed"] is False
+
+
+def test_polyline_set_multiple_polylines_with_constant_node_count():
+    _, _, pls, arrays = get_random_polyline_set(node_counts=[3, 3, 3])
+    fc = polyline_set_to_geojson(pls, arrays, crs=None)
+
+    assert fc["properties"]["polyline_count"] == 3
+    assert [f["properties"]["node_count"] for f in fc["features"]] == [3, 3, 3]
+    assert [f["properties"]["polyline_index"] for f in fc["features"]] == [0, 1, 2]
+    for f in fc["features"]:
+        assert len(f["geometry"]["coordinates"]) == 3
+
+
+def test_polyline_set_emits_crs_block_for_epsg_in_extra_metadata_shape():
+    """End-to-end on the epsg-in-extra-metadata shape: Time CRS with
+    BoundProjected EPSG codes hidden in extra_metadata. The resulting
+    FeatureCollection should carry the resolved EPSG codes at the top
+    level under ``crs.properties``.
+    """
+    crs = get_random_crs(
+        domain="time",
+        title=_TEST_CRS_TITLE_WITH_PT,
+        extra_metadata=[ro.NameValuePair(name="crs", value=_TEST_BOUND_PROJECTED)],
+    )
+    _, _, pls, arrays = get_random_polyline_set(crs=crs, node_counts=[4])
+
+    fc = polyline_set_to_geojson(
+        pls,
+        arrays,
+        crs=crs,
+        extra_properties={"fault_interpretation_title": "Test-Fault"},
+    )
+
+    assert fc["crs"]["type"] == "name"
+    crs_props = fc["crs"]["properties"]
+    assert crs_props["projected_epsg_code"] == _TEST_PROJ_EPSG
+    assert crs_props["vertical_epsg_code"] == _TEST_VERT_EPSG
+    assert crs_props["z_domain"] == "time"
+    assert crs_props["name"] == f"urn:ogc:def:crs:EPSG::{_TEST_PROJ_EPSG}"
+
+    for f in fc["features"]:
+        assert f["properties"]["fault_interpretation_title"] == "Test-Fault"
+
+
+def test_polyline_set_skips_degenerate_single_point_polylines():
+    _, _, pls, arrays = get_random_polyline_set(node_counts=[1, 3])
+    fc = polyline_set_to_geojson(pls, arrays, crs=None)
+
+    # Only the 3-point polyline should survive — LineString needs >=2 nodes.
+    assert fc["properties"]["polyline_count"] == 1
+    assert fc["features"][0]["properties"]["node_count"] == 3
+    assert fc["features"][0]["properties"]["polyline_index"] == 1
+
+
+def test_polyline_set_unknown_points_path_raises():
+    _, _, pls, _ = get_random_polyline_set(node_counts=[3])
+    with pytest.raises(KeyError):
+        polyline_set_to_geojson(pls, arrays={}, crs=None)
+
+
+def test_polyline_set_inconsistent_node_count_sum_raises():
+    _, _, pls, arrays = get_random_polyline_set(node_counts=[3, 3])
+    # Tamper with the points array so the sum no longer matches.
+    points_path = pls.line_patch[0].geometry.points.coordinates.path_in_hdf_file
+    arrays = dict(arrays)
+    arrays[points_path] = arrays[points_path][:5]
+    with pytest.raises(ValueError, match="node_count_per_polyline sums to"):
+        polyline_set_to_geojson(pls, arrays, crs=None)
+
+
+def test_get_geojson_method_matches_free_function():
+    """``polyline.get_geojson(arrays, crs)`` must produce the same output as
+    calling ``polyline_set_to_geojson(polyline, arrays, crs)`` directly.
+    """
+    crs = get_random_crs(
+        domain="time",
+        title=_TEST_CRS_TITLE_WITH_PT,
+        extra_metadata=[ro.NameValuePair(name="crs", value=_TEST_BOUND_PROJECTED)],
+    )
+    _, _, pls, arrays = get_random_polyline_set(crs=crs, node_counts=[4])
+
+    via_method = pls.get_geojson(arrays, crs)
+    via_function = polyline_set_to_geojson(pls, arrays, crs)
+
+    assert dict(via_method) == dict(via_function)
+
+
+def test_get_geojson_method_accepts_extra_properties_and_name():
+    _, _, pls, arrays = get_random_polyline_set(node_counts=[3])
+    fc = pls.get_geojson(
+        arrays,
+        crs=None,
+        extra_properties={"fault_interpretation_title": "TestFault-1"},
+        name="my-fault",
+    )
+
+    assert fc["name"] == "my-fault"
+    assert (
+        fc["features"][0]["properties"]["fault_interpretation_title"] == "TestFault-1"
+    )
+
+
+def test_patch_decode_returns_arrays():
+    _, _, pls, arrays = get_random_polyline_set(node_counts=[3, 3, 3])
+
+    points, node_counts, closed = pls.line_patch[0].decode(arrays)
+
+    assert points.shape == (9, 3)
+    assert points.dtype == np.float64
+    assert node_counts.tolist() == [3, 3, 3]
+    assert node_counts.dtype == np.int64
+    assert closed.tolist() == [False, False, False]
+    assert closed.dtype == np.bool_
+
+
+def test_patch_decode_xy_z_access_via_points():
+    """``points[:, 0]`` etc. is how you get raw x / y / z columns."""
+    _, _, pls, arrays = get_random_polyline_set(node_counts=[5])
+    points, _, _ = pls.line_patch[0].decode(arrays)
+
+    # x/y/z columns must round-trip from the original input array.
+    points_path = pls.line_patch[0].geometry.points.coordinates.path_in_hdf_file
+    expected = arrays[points_path]
+    np.testing.assert_array_equal(points[:, 0], expected[:, 0])
+    np.testing.assert_array_equal(points[:, 1], expected[:, 1])
+    np.testing.assert_array_equal(points[:, 2], expected[:, 2])


### PR DESCRIPTION
Adds support for reading fault representations (obj_PolylineSetRepresentation) from RDDMS and converting them in-memory to a GeoJSON FeatureCollection. 