### PR TITLE
Fixing the mismatched position of surface and Faults

### DIFF
--- a/src/resqml_objects/v201/generated.py
+++ b/src/resqml_objects/v201/generated.py
@@ -22686,8 +22686,11 @@ class obj_PolylineSetRepresentation(AbstractRepresentation):
 
         Walks the polyline-set's HDF5 geometry via ``patch.decode(arrays)``
         and resolves the CRS via ``crs._resolve_crs()``, emitting one
-        ``LineString`` Feature per polyline. Coordinates stay in the source
-        CRS
+        ``LineString`` Feature per polyline. When a ``crs`` is supplied, the
+        stored local-CRS coordinates are lifted into the CRS's projected frame
+        by adding ``crs.xoffset`` / ``crs.yoffset`` (the same translation the
+        surface path applies in ``get_regular_surface_parameters``), so the
+        emitted coordinates match the projected EPSG code in the ``crs`` block.
 
         Parameters
         ----------
@@ -22721,11 +22724,17 @@ class obj_PolylineSetRepresentation(AbstractRepresentation):
                 "type": "name",
                 "properties": {"name": crs_name, **block_props},
             }
+        x_offset = float(crs.xoffset) if crs is not None else 0.0
+        y_offset = float(crs.yoffset) if crs is not None else 0.0
 
         features: list[Any] = []
         polyline_index = 0
         for patch in self.line_patch:
             points, node_counts, closed = patch.decode(arrays)
+            if x_offset or y_offset:
+                points = points.astype(float, copy=True)
+                points[:, 0] += x_offset
+                points[:, 1] += y_offset
             cursor = 0
             for i_in_patch, n in enumerate(node_counts):
                 idx = polyline_index

--- a/tests/test_geojson_export.py
+++ b/tests/test_geojson_export.py
@@ -287,6 +287,48 @@ def test_resolve_crs_ow_style_name() -> None:
     assert info["name"] == "TEST_CRS_NAME_OW_STYLE"
 
 
+def test_polyline_set_applies_crs_xy_offset_to_coordinates() -> None:
+    """Local-CRS points must be lifted into the projected frame using the CRS
+    x/y offset, so faults line up with surfaces decoded via
+    ``get_regular_surface_parameters`` (which adds the same offset).
+    """
+    crs = get_random_crs(
+        projected_crs=ro.ProjectedCrsEpsgCode(epsg_code=23031),
+        vertical_crs=ro.VerticalCrsEpsgCode(epsg_code=6230),
+    )
+    crs.xoffset = 420000.0
+    crs.yoffset = 6470000.0
+
+    points = np.array(
+        [
+            [13725.0, 9583.0, 3490.0],
+            [13700.0, 9500.0, 3490.0],
+            [13670.0, 9440.0, 3490.0],
+        ],
+        dtype=np.float64,
+    )
+    _, _, pls, arrays = get_random_polyline_set(crs=crs, node_counts=[3], points=points)
+
+    fc = polyline_set_to_geojson(pls, arrays, crs=crs)
+    coords = np.asarray(fc["features"][0]["geometry"]["coordinates"])
+
+    expected = points.copy()
+    expected[:, 0] += crs.xoffset
+    expected[:, 1] += crs.yoffset
+    np.testing.assert_allclose(coords, expected, atol=1e-6)
+
+
+def test_polyline_set_no_offset_leaves_coordinates_unchanged() -> None:
+    """A CRS with zero x/y offset (the default) must not move coordinates."""
+    points = np.array([[10.0, 20.0, 30.0], [11.0, 21.0, 31.0]], dtype=np.float64)
+    crs, _, pls, arrays = get_random_polyline_set(node_counts=[2], points=points)
+    assert crs.xoffset == 0.0 and crs.yoffset == 0.0
+
+    fc = polyline_set_to_geojson(pls, arrays, crs=crs)
+    coords = np.asarray(fc["features"][0]["geometry"]["coordinates"])
+    np.testing.assert_allclose(coords, points, atol=1e-9)
+
+
 # -----------------------------------------------------------------------------
 # Naive helpers — get_epsg_code / get_wkt / is_time_domain / is_depth_domain
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Take into account a potential Offset in the LocalCRS when returning a GeoJSON