### PR TITLE
Fixing the namespace error

### DIFF
--- a/src/resqml_objects/parsers.py
+++ b/src/resqml_objects/parsers.py
@@ -1,4 +1,7 @@
+import os
+
 from lxml import etree
+from xsdata.exceptions import ConverterError
 from xsdata.formats.dataclass.models.generics import DerivedElement
 from xsdata.formats.dataclass.parsers import XmlParser
 
@@ -6,9 +9,37 @@ import resqml_objects.v201 as ro_201
 from resqml_objects.serializers import RO201Obj, RO201SubObj
 
 xsi_type_key = "{http://www.w3.org/2001/XMLSchema-instance}type"
+_PATCH_FLAG_ENV = "PYETP_PATCH_MISSING_XSD_NAMESPACE"
+_XSD_DECL = b'xmlns:xsd="http://www.w3.org/2001/XMLSchema"'
+_XSI_DECL = b'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
 
 
-def parse_resqml_v201_object(raw_data: bytes) -> RO201Obj | RO201SubObj:
+def _patch_missing_xsd_namespace_enabled() -> bool:
+    raw = os.environ.get(_PATCH_FLAG_ENV)
+    if raw is None:
+        return True
+    return raw.strip().lower() not in {"0", "false", "no", "off", ""}
+
+
+def _inject_xsd_namespace(raw_data: bytes) -> bytes:
+    """Inject ``xmlns:xsd="..."`` into the root element by piggy-backing on
+    the existing ``xmlns:xsi`` declaration.
+
+    Returns the bytes unchanged when there is nothing to patch (no ``xsi``
+    declaration to hook onto, or ``xsd`` is already declared).
+    """
+
+    if _XSD_DECL in raw_data:
+        return raw_data
+
+    return raw_data.replace(
+        _XSI_DECL,
+        _XSI_DECL + b" " + _XSD_DECL,
+        1,
+    )
+
+
+def _parse(raw_data: bytes) -> RO201Obj | RO201SubObj:
     parser = XmlParser()
 
     xml_obj = etree.fromstring(raw_data)
@@ -23,3 +54,17 @@ def parse_resqml_v201_object(raw_data: bytes) -> RO201Obj | RO201SubObj:
     )
 
     return ret_obj
+
+
+def parse_resqml_v201_object(raw_data: bytes) -> RO201Obj | RO201SubObj:
+    if not _patch_missing_xsd_namespace_enabled():
+        return _parse(raw_data)
+
+    try:
+        return _parse(raw_data)
+    except ConverterError:
+        patched = _inject_xsd_namespace(raw_data)
+        if patched == raw_data:
+            # Nothing to patch — this is something different error, propagate it.
+            raise
+        return _parse(patched)

--- a/src/resqml_objects/parsers.py
+++ b/src/resqml_objects/parsers.py
@@ -1,4 +1,4 @@
-import os
+from os import environ
 
 from lxml import etree
 from xsdata.exceptions import ConverterError
@@ -15,7 +15,7 @@ _XSI_DECL = b'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
 
 
 def _patch_missing_xsd_namespace_enabled() -> bool:
-    raw = os.environ.get(_PATCH_FLAG_ENV)
+    raw = environ.get(_PATCH_FLAG_ENV)
     if raw is None:
         return True
     return raw.strip().lower() not in {"0", "false", "no", "off", ""}
@@ -25,8 +25,7 @@ def _inject_xsd_namespace(raw_data: bytes) -> bytes:
     """Inject ``xmlns:xsd="..."`` into the root element by piggy-backing on
     the existing ``xmlns:xsi`` declaration.
 
-    Returns the bytes unchanged when there is nothing to patch (no ``xsi``
-    declaration to hook onto, or ``xsd`` is already declared).
+    Returns the bytes unchanged when there is nothing to patch
     """
 
     if _XSD_DECL in raw_data:
@@ -57,14 +56,15 @@ def _parse(raw_data: bytes) -> RO201Obj | RO201SubObj:
 
 
 def parse_resqml_v201_object(raw_data: bytes) -> RO201Obj | RO201SubObj:
+    """
+    Parse the RESQML object from raw bytes;  If a flag (env var) is not unset, we prevent
+       xsd namespace declaration errors by patching the raw XML data accordingly.
+       For performance reasons, the patching is done only when a ConverterError was thrown
+    """
     if not _patch_missing_xsd_namespace_enabled():
         return _parse(raw_data)
-
     try:
         return _parse(raw_data)
     except ConverterError:
         patched = _inject_xsd_namespace(raw_data)
-        if patched == raw_data:
-            # Nothing to patch — this is something different error, propagate it.
-            raise
         return _parse(patched)

--- a/tests/test_resqmlv201_objects.py
+++ b/tests/test_resqmlv201_objects.py
@@ -4,6 +4,7 @@ import datetime
 import numpy as np
 import pytest
 from lxml import etree
+from xsdata.exceptions import ConverterError
 from xsdata.models.datatype import XmlDateTime
 
 import resqml_objects.v201 as ro
@@ -738,3 +739,39 @@ def test_is_supported_regular_surface() -> None:
     populated = model.populate_data_references()
     assert isinstance(populated, ro.obj_Grid2dRepresentation)
     assert populated.is_supported_regular_surface() is True
+
+
+_MALFORMED_CITATION_XML = (
+    b'<?xml version="1.0" encoding="UTF-8"?>'
+    b"<eml:Citation"
+    b' xmlns:eml="http://www.energistics.org/energyml/data/commonv2"'
+    b' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
+    b' xsi:type="eml:Citation">'
+    b'<eml:Title xsi:type="xsd:string">fault</eml:Title>'
+    b'<eml:Originator xsi:type="xsd:string">test producer</eml:Originator>'
+    b'<eml:Format xsi:type="xsd:string">RESQML v2.0</eml:Format>'
+    b"</eml:Citation>"
+)
+
+
+def test_parser_auto_patches_missing_xsd_namespace_by_default() -> None:
+    """The parser should tolerate malformed RESQML that uses `xsd:` without
+    declaring `xmlns:xsd` — by injecting the declaration on the way in.
+    """
+    parsed = parse_resqml_v201_object(_MALFORMED_CITATION_XML)
+    assert isinstance(parsed, ro.Citation)
+    assert parsed.title == "fault"
+    assert parsed.originator == "test producer"
+
+
+def test_parser_can_be_made_strict_via_env_var(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Setting `PYETP_PATCH_MISSING_XSD_NAMESPACE=0` (or any falsy value)
+    disables the auto-patch — the strict xsdata behaviour returns and the
+    same malformed payload raises ConverterError.
+    """
+
+    monkeypatch.setenv("PYETP_PATCH_MISSING_XSD_NAMESPACE", "0")
+    with pytest.raises(ConverterError, match="Unknown namespace prefix"):
+        parse_resqml_v201_object(_MALFORMED_CITATION_XML)


### PR DESCRIPTION
Some surfaces read from RDDMS are missing the XSD namespace. As a result, parsing data from RDDMS to RESQML throws an exception. This change injects the XSD namespace when it is missing, allowing the parser to handle such data gracefully.